### PR TITLE
add fewshot_as_multiturn param

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,6 +109,13 @@ def run_eval(eval_name, args):
     else:
         env_vars['APPLY_CHAT_TEMPLATE'] = args.apply_chat_template
 
+    if args.fewshot_as_multiturn is False:
+        env_vars['FEWSHOT_AS_MULTITURN'] = "False"
+    elif args.fewshot_as_multiturn is True:
+        env_vars['FEWSHOT_AS_MULTITURN'] = "True"
+    else:
+        env_vars['FEWSHOT_AS_MULTITURN'] = args.apply_chat_template
+
     slurm_config = {
         'name': eval_name,
         'account': args.project,
@@ -144,7 +151,10 @@ def run_eval(eval_name, args):
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
-    process = subprocess.run(['sbatch', script_name], capture_output=True, text=True)
+    # process = subprocess.run(['sbatch', script_name], capture_output=True, text=True)
+    process = subprocess.run(['sbatch', script_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    stdout = process.stdout
+    stderr = process.stderr
     if process.returncode != 0:
         print(f"Error: sbatch command failed with return code {process.returncode}")
         print(process.stderr)
@@ -201,7 +211,17 @@ def main():
             "To specificy a particular template, supply its name (see lm_eval options)"
         )
     )
-
+    parser.add_argument(
+        '--fewshot_as_multiturn',
+        nargs='?',
+        const=True,
+        default=False,
+        type=str,
+        help=(
+            "If true, treat few-shot prompts as multiturn conversation. "
+            "If provided without an argument, applies the default behaviour. "
+        )
+    )
     # slurm config
     parser.add_argument('--project', type=str, default="project_462000353", help="Project for sbatch job")
     parser.add_argument('--partition', type=str, default="small-g", help="Partition for sbatch job")
@@ -229,12 +249,12 @@ def main():
             print(f"Error: tokenizer '{args.tokenizer}' looks like a directory, but does not contain a tokenizer.json")
             sys.exit(1)
 
-    scheduled_tasks = identify_scheduled_tasks()
+    # scheduled_tasks = identify_scheduled_tasks()
     for eval_name in args.eval:
-        task = scheduled_tasks.get((args.model, eval_name), None)
-        if task is not None and not args.force:
-            print(f"Already detected job for {task['eval']} on {task['model']} on slurm job {task['job_id']} and --force not specified, skipping...")
-            continue
+        # task = scheduled_tasks.get((args.model, eval_name), None)
+        # if task is not None and not args.force:
+        #     print(f"Already detected job for {task['eval']} on {task['model']} on slurm job {task['job_id']} and --force not specified, skipping...")
+        #     continue
         run_eval(eval_name, args)
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -109,12 +109,10 @@ def run_eval(eval_name, args):
     else:
         env_vars['APPLY_CHAT_TEMPLATE'] = args.apply_chat_template
 
-    if args.fewshot_as_multiturn is False:
-        env_vars['FEWSHOT_AS_MULTITURN'] = "False"
-    elif args.fewshot_as_multiturn is True:
-        env_vars['FEWSHOT_AS_MULTITURN'] = "True"
+    if args.fewshot_as_multiturn is None:
+        env_vars['FEWSHOT_AS_MULTITURN'] = str(args.apply_chat_template)
     else:
-        env_vars['FEWSHOT_AS_MULTITURN'] = args.apply_chat_template
+        env_vars['FEWSHOT_AS_MULTITURN'] = str(args.fewshot_as_multiturn)
 
     slurm_config = {
         'name': eval_name,
@@ -151,10 +149,7 @@ def run_eval(eval_name, args):
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
-    # process = subprocess.run(['sbatch', script_name], capture_output=True, text=True)
     process = subprocess.run(['sbatch', script_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-    stdout = process.stdout
-    stderr = process.stderr
     if process.returncode != 0:
         print(f"Error: sbatch command failed with return code {process.returncode}")
         print(process.stderr)
@@ -216,7 +211,7 @@ def main():
         nargs='?',
         const=True,
         default=False,
-        type=str,
+        type=lambda x: str(x).lower() == 'true' if x is not None else True,
         help=(
             "If true, treat few-shot prompts as multiturn conversation. "
             "If provided without an argument, applies the default behaviour. "

--- a/main.py
+++ b/main.py
@@ -249,12 +249,12 @@ def main():
             print(f"Error: tokenizer '{args.tokenizer}' looks like a directory, but does not contain a tokenizer.json")
             sys.exit(1)
 
-    # scheduled_tasks = identify_scheduled_tasks()
+    scheduled_tasks = identify_scheduled_tasks()
     for eval_name in args.eval:
-        # task = scheduled_tasks.get((args.model, eval_name), None)
-        # if task is not None and not args.force:
-        #     print(f"Already detected job for {task['eval']} on {task['model']} on slurm job {task['job_id']} and --force not specified, skipping...")
-        #     continue
+        task = scheduled_tasks.get((args.model, eval_name), None)
+        if task is not None and not args.force:
+            print(f"Already detected job for {task['eval']} on {task['model']} on slurm job {task['job_id']} and --force not specified, skipping...")
+            continue
         run_eval(eval_name, args)
 
 if __name__ == "__main__":

--- a/templates/lm_eval_harness2.sh
+++ b/templates/lm_eval_harness2.sh
@@ -193,8 +193,6 @@ if [ "$FEWSHOT_AS_MULTITURN" = "False" ]; then
     FEWSHOT_AS_MULTITURN=""
 elif [ "$FEWSHOT_AS_MULTITURN" = "True" ]; then
     FEWSHOT_AS_MULTITURN="--fewshot_as_multiturn"
-else
-    FEWSHOT_AS_MULTITURN="--fewshot_as_multiturn ${FEWSHOT_AS_MULTITURN}"
 fi
 
 set -x

--- a/templates/lm_eval_harness2.sh
+++ b/templates/lm_eval_harness2.sh
@@ -58,6 +58,10 @@ if [ -z "$WORK_DIR" ]; then
     echo "WORK_DIR is not set"
     exit 1
 fi
+if [ -z "$FEWSHOT_AS_MULTITURN" ]; then
+    echo "FEWSHOT_AS_MULTITURN is not set"
+    exit 1
+fi
 
 # set up environment
 WORK_DIR=$WORK_DIR/lm_eval_harness
@@ -133,6 +137,8 @@ echo "Acquired lock (Job ID: $SLURM_JOB_ID), executing environment setup code."
 python -m venv venv.lm-evaluation-harness2
 source venv.lm-evaluation-harness2/bin/activate
 
+export HF_HOME="/scratch/project_462000353/hf_cache"
+
 if [ ! -d lm-evaluation-harness2 ] ; then
    	git clone -b main https://github.com/jonabur/lm-evaluation-harness lm-evaluation-harness2
 fi
@@ -148,8 +154,9 @@ pip install jinja2 --upgrade  # missing requirement?
 pip install sentencepiece --upgrade  # required for 01-ai/Yi
 pip install protobuf --upgrade       # required for Llama 2 tokenizer
 pip install tiktoken --upgrade
-pip install langdetect --upgrade # required for ifeval_fi and ifeval_sv
-pip install immutabledict --upgrade # required for ifeval_fi and ifeval_sv
+pip install langdetect --upgrade # required for ifeval
+pip install immutabledict --upgrade # required for ifeval
+pip install heliport --upgrade # required for ifeval_fi, use heli-ots instead of langdetect
 
 pip install -e .
 pip install -e .[math]
@@ -182,6 +189,14 @@ else
     CHAT_TEMPLATE_FLAG="--apply_chat_template ${APPLY_CHAT_TEMPLATE}"
 fi
 
+if [ "$FEWSHOT_AS_MULTITURN" = "False" ]; then
+    FEWSHOT_AS_MULTITURN=""
+elif [ "$FEWSHOT_AS_MULTITURN" = "True" ]; then
+    FEWSHOT_AS_MULTITURN="--fewshot_as_multiturn"
+else
+    FEWSHOT_AS_MULTITURN="--fewshot_as_multiturn ${FEWSHOT_AS_MULTITURN}"
+fi
+
 set -x
 lm_eval \
     --model hf \
@@ -189,8 +204,10 @@ lm_eval \
     --tasks "$TASK_LIST" \
     --num_fewshot $NUM_FEWSHOT \
     --output_path $RANDOM_DIR \
-    $CHAT_TEMPLATE_FLAG
-    # --log_samples 
+    --log_samples \
+    $CHAT_TEMPLATE_FLAG \
+    $FEWSHOT_AS_MULTITURN 
+    
 set +x
 
 echo Moving temporary results from $RANDOM_DIR to $OUTPUT_FILE

--- a/templates/lm_eval_harness2.sh
+++ b/templates/lm_eval_harness2.sh
@@ -204,7 +204,6 @@ lm_eval \
     --tasks "$TASK_LIST" \
     --num_fewshot $NUM_FEWSHOT \
     --output_path $RANDOM_DIR \
-    --log_samples \
     $CHAT_TEMPLATE_FLAG \
     $FEWSHOT_AS_MULTITURN 
     


### PR DESCRIPTION
Allow user to set the fewshot_as_multiturn flag when running evals. This is useful for evaluating chat models.

- add the new argument --fewshot_as_multiturn in main.py 
- pass the value of --fewshot_as_multiturn to lm_eval in templates/lm_eval_harness2.sh