### PR TITLE
autodetect chat template, restore fewshot as multiturn functionality, add back some missing pip installs

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,18 +101,9 @@ def run_eval(eval_name, args):
         'WORK_DIR': os.path.abspath(args.work_dir),
         'OUTPUT_FILE': output_file,
         'TRUST_REMOTE_CODE': "True" if args.trust_remote_code else "False",
+        'APPLY_CHAT_TEMPLATE': args.apply_chat_template,
+        'FEWSHOT_AS_MULTITURN': args.fewshot_as_multiturn,
     }
-    if args.apply_chat_template is False:
-        env_vars['APPLY_CHAT_TEMPLATE'] = "False"
-    elif args.apply_chat_template is True:
-        env_vars['APPLY_CHAT_TEMPLATE'] = "True"
-    else:
-        env_vars['APPLY_CHAT_TEMPLATE'] = args.apply_chat_template
-
-    if args.fewshot_as_multiturn is None:
-        env_vars['FEWSHOT_AS_MULTITURN'] = str(args.apply_chat_template)
-    else:
-        env_vars['FEWSHOT_AS_MULTITURN'] = str(args.fewshot_as_multiturn)
 
     slurm_config = {
         'name': eval_name,
@@ -183,6 +174,18 @@ def run_eval(eval_name, args):
         f.write(json.dumps(log_entry) + "\n")
     print(json.dumps(log_entry, indent=4))
 
+def parse_chat_flag(v):
+    if v is None:  # flag supplied without value -> True
+        return "True"
+    v_low = v.lower()
+    if v_low in {"true", "t", "1"}:
+        return "True"
+    if v_low in {"false", "f", "0"}:
+        return "False"
+    if v_low == "auto":
+        return "auto"
+    raise argparse.ArgumentTypeError("Expected True / False / auto (leave blank for True)")
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('eval', type=str, nargs='+', choices=list(evals.keys()), default='finbench', help='Which eval to run')
@@ -197,25 +200,18 @@ def main():
     parser.add_argument(
         '--apply_chat_template',
         nargs='?',
-        const=True,
-        default=False,
-        type=str,
-        help=(
-            "If true, apply the default chat template. "
-            "If provided without an argument, applies the default template. "
-            "To specificy a particular template, supply its name (see lm_eval options)"
-        )
+        const=None,
+        default="auto",
+        type=parse_chat_flag,
+        help="auto (default) = detect from tokenizer; True/False = force",
     )
     parser.add_argument(
         '--fewshot_as_multiturn',
         nargs='?',
-        const=True,
-        default=False,
-        type=lambda x: str(x).lower() == 'true' if x is not None else True,
-        help=(
-            "If true, treat few-shot prompts as multiturn conversation. "
-            "If provided without an argument, applies the default behaviour. "
-        )
+        const=None,
+        default="auto",
+        type=parse_chat_flag,
+        help="auto (default) = match apply_chat_template setting; True/False = force",
     )
     # slurm config
     parser.add_argument('--project', type=str, default="project_462000353", help="Project for sbatch job")

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -50,19 +50,26 @@ if [ -z "$TRUST_REMOTE_CODE" ]; then
     echo "TRUST_REMOTE_CODE is not set"
     exit 1
 fi
-if [ -z "$APPLY_CHAT_TEMPLATE" ]; then
-    echo "APPLY_CHAT_TEMPLATE is not set"
-    exit 1
-fi
 if [ -z "$WORK_DIR" ]; then
     echo "WORK_DIR is not set"
     exit 1
 fi
+if [ -z "$APPLY_CHAT_TEMPLATE" ]; then
+    echo "APPLY_CHAT_TEMPLATE is not set"
+    exit 1
+fi
+if [ -z "$FEWSHOT_AS_MULTITURN" ]; then
+    echo "FEWSHOT_AS_MULTITURN is not set"
+    exit 1
+fi
+
 
 # Remove any venv settings that might confuse things.
 unset PYTHONPATH
 unset PYTHONHOME
 unset VIRTUAL_ENV
+
+export HF_HOME="/scratch/project_462000353/hf_cache"
 
 # Prepare work dir
 WORK_DIR=$WORK_DIR/lm_eval_harness
@@ -183,14 +190,15 @@ echo PYTHONUSERBASE is $PYTHONUSERBASE
 export PATH=$PATH:$PYTHONUSERBASE/bin
 pip install --upgrade setuptools pip
 pip --python=/appl/local/csc/soft/ai/bin/python install --user  -e .[hf_transfer,math,multilingual,sentencepiece,ifeval]
+pip install --upgrade langdetect immutabledict heliport
 
 # remove cleanup trap and release lock
 trap - EXIT
 cleanup
 echo "Environment setup complete."
 
-### Prepare to run command
 
+### Prepare to run command
 echo Cuda Available: "$(python -c 'import torch; print(torch.cuda.is_available())')"
 
 # lm_eval has changed so that --output_path is treated as a directory and the
@@ -204,13 +212,45 @@ echo Saving temporary results to $RANDOM_DIR
 mkdir -p $OUTPUT_DIR
 echo Final results will be saved to: $OUTPUT_FILE
 
-if [ "$APPLY_CHAT_TEMPLATE" = "False" ]; then
-    CHAT_TEMPLATE_FLAG=""
-elif [ "$APPLY_CHAT_TEMPLATE" = "True" ]; then
+
+### Chat template detection and configuration
+
+detect_chat_template () {
+  python - <<'PY'
+from transformers import AutoTokenizer
+import json, os, sys
+name   = os.environ["TOKENIZER"]
+trust  = os.getenv("TRUST_REMOTE_CODE", "False").lower() == "true"
+cfg    = AutoTokenizer.from_pretrained(name, trust_remote_code=trust)
+print("True" if getattr(cfg, "chat_template", None) else "False")
+PY
+}
+if [ "$APPLY_CHAT_TEMPLATE" = "auto" ]; then 
+    echo Detecting chat template for tokenizer $TOKENIZER
+    CHAT_TEMPLATE_DETECTED=$(detect_chat_template)
+    echo Chat template for $TOKENIZER is $CHAT_TEMPLATE_DETECTED
+fi
+if [ "$APPLY_CHAT_TEMPLATE" = "auto" ] ; then 
+    APPLY_CHAT_TEMPLATE=$CHAT_TEMPLATE_DETECTED
+fi
+
+if [ "$APPLY_CHAT_TEMPLATE" = "True" ]; then
     CHAT_TEMPLATE_FLAG="--apply_chat_template"
 else
-    CHAT_TEMPLATE_FLAG="--apply_chat_template ${APPLY_CHAT_TEMPLATE}"
+    CHAT_TEMPLATE_FLAG=""
 fi
+
+if [ "$FEWSHOT_AS_MULTITURN" = "auto" ] ; then
+    FEWSHOT_AS_MULTITURN=$APPLY_CHAT_TEMPLATE
+fi
+
+if [ "$FEWSHOT_AS_MULTITURN" = "True" ]; then
+    FEWSHOT_AS_MULTITURN_FLAG="--fewshot_as_multiturn"
+else
+    FEWSHOT_AS_MULTITURN_FLAG=""
+fi
+
+### Launch command
 
 set -x
 lm_eval \
@@ -219,8 +259,9 @@ lm_eval \
     --tasks "$TASK_LIST" \
     --num_fewshot $NUM_FEWSHOT \
     --output_path $RANDOM_DIR \
-    $CHAT_TEMPLATE_FLAG
-    # --log_samples 
+    $CHAT_TEMPLATE_FLAG \
+    $FEWSHOT_AS_MULTITURN_FLAG
+    # --log_samples \
 set +x
 
 echo Moving temporary results from $RANDOM_DIR to $OUTPUT_FILE

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -229,8 +229,8 @@ if [ "$APPLY_CHAT_TEMPLATE" = "auto" ]; then
     echo Detecting chat template for tokenizer $TOKENIZER
     CHAT_TEMPLATE_DETECTED=$(detect_chat_template)
     echo Chat template for $TOKENIZER is $CHAT_TEMPLATE_DETECTED
-fi
-if [ "$APPLY_CHAT_TEMPLATE" = "auto" ] ; then 
+
+    # update value to True or False for subsequent logic
     APPLY_CHAT_TEMPLATE=$CHAT_TEMPLATE_DETECTED
 fi
 


### PR DESCRIPTION
new chat detection functionality is:
- apply chat template is autodect, can be overridden to true or false on the command line
- fewshot automatically matches chat template setting by default, can be overridden to true or false on the command line

I tested this with a chat and non-chat model and the detection worked correctly with the default arguments. 

also restored the pip installs that got list in the template migration