### PR TITLE
undo auto chat template detection

### DIFF
--- a/chat.sh
+++ b/chat.sh
@@ -2,12 +2,12 @@ QUEUE=standard-g
 PROJECT=project_462000615
 
 # this can go very long in models that are not good at this language, i guess?
-python3 main.py --time 01:00:00 --project $PROJECT --partition $QUEUE --model $1 flores200_trans_en_fi flores200_trans_fi_en
-python3 main.py --time 6:00:00 --project $PROJECT --partition $QUEUE --model $1 arc_challenge arc_challenge_mt_fi truthfulqa_mc truthfulqa_mc_mt_fi
-python3 main.py --time 8:00:00 --project $PROJECT --partition $QUEUE --model $1 mmlu_mt_fi
-python3 main.py --time 24:00:00 --project $PROJECT --partition $QUEUE --model $1 hellaswag_mt_fi
-python3 main.py --time 24:00:00 --project $PROJECT --partition $QUEUE --model $1 hellaswag
-python3 main.py --time 8:00:00 --project $PROJECT --partition $QUEUE --model $1 mmlu
-python3 main.py --time 8:00:00 --project $PROJECT --partition $QUEUE --model $1 gsm8k gsm8k_mt_fi
-python3 main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 ifeval ifeval_fi
-python3 main.py --time 04:00:00 --project $PROJECT --partition $QUEUE --model $1 goldenswag_mt_fi
+python3 main.py --time 3:00:00 --project $PROJECT --partition $QUEUE --apply_chat_template --fewshot_as_multiturn --model $1 flores200_trans_en_fi flores200_trans_fi_en
+python3 main.py --time 18:00:00 --project $PROJECT --partition $QUEUE --apply_chat_template --fewshot_as_multiturn --model $1 arc_challenge arc_challenge_mt_fi truthfulqa_mc truthfulqa_mc_mt_fi
+python3 main.py --time 12:00:00 --project $PROJECT --partition $QUEUE --apply_chat_template --fewshot_as_multiturn --model $1 mmlu_mt_fi
+python3 main.py --time 48:00:00 --project $PROJECT --partition $QUEUE --apply_chat_template --fewshot_as_multiturn --model $1 hellaswag_mt_fi
+python3 main.py --time 48:00:00 --project $PROJECT --partition $QUEUE --apply_chat_template --fewshot_as_multiturn --model $1 hellaswag
+python3 main.py --time 12:00:00 --project $PROJECT --partition $QUEUE --apply_chat_template --fewshot_as_multiturn --model $1 mmlu
+python3 main.py --time 12:00:00 --project $PROJECT --partition $QUEUE --apply_chat_template --fewshot_as_multiturn --model $1 gsm8k gsm8k_mt_fi
+python3 main.py --time 20:00:00 --project $PROJECT --partition $QUEUE --apply_chat_template --fewshot_as_multiturn --model $1 ifeval
+python3 main.py --time 24:00:00 --project $PROJECT --partition $QUEUE --apply_chat_template --fewshot_as_multiturn --model $1 ifeval_fi

--- a/main.py
+++ b/main.py
@@ -200,18 +200,25 @@ def main():
     parser.add_argument(
         '--apply_chat_template',
         nargs='?',
-        const=None,
-        default="auto",
-        type=parse_chat_flag,
-        help="auto (default) = detect from tokenizer; True/False = force",
+        const=True,
+        default=False,
+        type=str,
+        help=(
+            "If true, apply the default chat template. "
+            "If provided without an argument, applies the default template. "
+            "To specificy a particular template, supply its name (see lm_eval options)"
+        )
     )
     parser.add_argument(
         '--fewshot_as_multiturn',
         nargs='?',
-        const=None,
-        default="auto",
-        type=parse_chat_flag,
-        help="auto (default) = match apply_chat_template setting; True/False = force",
+        const=True,
+        default=False,
+        type=lambda x: str(x).lower() == 'true' if x is not None else True,
+        help=(
+            "If true, treat few-shot prompts as multiturn conversation. "
+            "If provided without an argument, applies the default behaviour. "
+        )
     )
     # slurm config
     parser.add_argument('--project', type=str, default="project_462000353", help="Project for sbatch job")

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -213,36 +213,12 @@ mkdir -p $OUTPUT_DIR
 echo Final results will be saved to: $OUTPUT_FILE
 
 
-### Chat template detection and configuration
-
-detect_chat_template () {
-  python - <<'PY'
-from transformers import AutoTokenizer
-import json, os, sys
-name   = os.environ["TOKENIZER"]
-trust  = os.getenv("TRUST_REMOTE_CODE", "False").lower() == "true"
-cfg    = AutoTokenizer.from_pretrained(name, trust_remote_code=trust)
-print("True" if getattr(cfg, "chat_template", None) else "False")
-PY
-}
-if [ "$APPLY_CHAT_TEMPLATE" = "auto" ]; then 
-    echo Detecting chat template for tokenizer $TOKENIZER
-    CHAT_TEMPLATE_DETECTED=$(detect_chat_template)
-    echo Chat template for $TOKENIZER is $CHAT_TEMPLATE_DETECTED
-
-    # update value to True or False for subsequent logic
-    APPLY_CHAT_TEMPLATE=$CHAT_TEMPLATE_DETECTED
-fi
-
 if [ "$APPLY_CHAT_TEMPLATE" = "True" ]; then
     CHAT_TEMPLATE_FLAG="--apply_chat_template"
 else
     CHAT_TEMPLATE_FLAG=""
 fi
 
-if [ "$FEWSHOT_AS_MULTITURN" = "auto" ] ; then
-    FEWSHOT_AS_MULTITURN=$APPLY_CHAT_TEMPLATE
-fi
 
 if [ "$FEWSHOT_AS_MULTITURN" = "True" ]; then
     FEWSHOT_AS_MULTITURN_FLAG="--fewshot_as_multiturn"


### PR DESCRIPTION
This is to undo the auto chat template detection feature and automatic setting of --apply_chat_template --fewshot_as_multiturn flags.

Expected behaviour: If user wants to set the apply_chat_template or fewshot_as_multiturn flags, they have to explicitly specify it in when calling main.py regardless of whether model they are evaluating has a chat template or not.

Reason for change: some models (e.g. Llama-3.3-70B-Instruct) get very different results when apply_chat_template or fewshot_as_multiturn flags are set or not. We want the user to try both modes if they want to.