### PR TITLE
standardize so goldenswag and goldenswag_mt_xx are 0 shot, whether or not its translated.

### DIFF
--- a/cpt.sh
+++ b/cpt.sh
@@ -2,7 +2,7 @@ QUEUE=standard-g
 PROJECT=project_462000353
 
 # this can go very long in models that are not good at this language, i guess?
-python main.py --time 06:00:00 --project $PROJECT --partition $QUEUE --model $1 flores200_trans_en_fi flores200_trans_fi_en
-python main.py --time 04:00:00 --project $PROJECT --partition $QUEUE --model $1 arc_challenge arc_challenge_mt_fi truthfulqa_mc truthfulqa_mc_mt_fi goldenswag_mt_fi
+python main.py --time 12:00:00 --project $PROJECT --partition $QUEUE --model $1 flores200_trans_en_fi flores200_trans_fi_en
+python main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 arc_challenge arc_challenge_mt_fi truthfulqa_mc truthfulqa_mc_mt_fi goldenswag_mt_fi
 python main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 mmlu mmlu_mt_fi
-python main.py --time 48:00:00 --project $PROJECT --partition $QUEUE --model $1 gsm8k gsm8k_mt_fi hellaswag hellaswag_mt_fi goldenswag goldenswag_0shot
+python main.py --time 48:00:00 --project $PROJECT --partition $QUEUE --model $1 gsm8k gsm8k_mt_fi hellaswag hellaswag_mt_fi goldenswag

--- a/evals/evals.py
+++ b/evals/evals.py
@@ -293,8 +293,8 @@ evals = {
     "lambada_openai":  LMEvalConfig("lambada_openai", "acc,none", num_fewshot=0),
     "lambada_standard":  LMEvalConfig("lambada_standard", "acc,none", num_fewshot=0),
 
-    "goldenswag": LMEvalConfig("goldenswag", "acc_norm,none", num_fewshot=10),
-    "goldenswag_0shot": LMEvalConfig("goldenswag", "acc_norm,none", num_fewshot=0),
+    "goldenswag": LMEvalConfig("goldenswag", "acc_norm,none", num_fewshot=0),
+    "goldenswag_10shot": LMEvalConfig("goldenswag", "acc_norm,none", num_fewshot=10),
 
     # code
     "humaneval_pass@1": BigcodeConfig("humaneval", n_samples=1),

--- a/summary.sh
+++ b/summary.sh
@@ -36,10 +36,6 @@ if [ -f $DIR/goldenswag.json ] ; then
 else
     echo na
 fi
-if [ -f $DIR/goldenswag_0shot.json ] ; then
-    echo -n " goldenswag_0shot: "
-    cat $DIR/goldenswag_0shot.json | jq '.results.goldenswag.acc_norm // .results.goldenswag["acc_norm,none"]' | awk '{print $1 * 100}'
-fi
 
 echo -n "             mmlu: "
 if [ -f $DIR/mmlu.json ] ; then
@@ -163,12 +159,6 @@ fi
 echo -n "    goldenswag_mt_fi: "
 if [ -f $DIR/goldenswag_mt_fi.json ] ; then
     cat $DIR/goldenswag_mt_fi.json | jq '.results.ogx_goldenswagx_fi."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n "    goldenswag_mt_fi_10shot: "
-if [ -f $DIR/goldenswag_mt_fi_10shot.json ] ; then
-    cat $DIR/goldenswag_mt_fi_10shot.json | jq '.results.ogx_goldenswagx_fi."acc,none"' | awk '{print $1 * 100}'
 else
     echo na
 fi


### PR DESCRIPTION
The naming of goldenswag evals was inconsistent depending on whether it was machine translated or not.  I'm standardizing on 0 shot as the default (as the original goldenswag paper was published) and leaving 10shot for now as an option, but I think we will probably not continue using it and may just delete it entirely later. 