### PR TITLE
reduce time holding lock

### DIFF
--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -106,7 +106,7 @@ cleanup() {
     fi
 }
 
-# Try to acquire the lock for up to 1 hour (7200 seconds)
+# Try to acquire the lock for up to 2 hour (7200 seconds)
 TIMEOUT=7200
 ATTEMPTS=0
 echo Acquiring lock for environment update: $LOCKFILE


### PR DESCRIPTION
jouni reported lock timeouts when launching a large number of jobs.

The long term fix for this will be to do this in the container and skip much of the work that we need to hold the lock for (maybe all of it, and can drop the lock entirely).

As a short term fix to reduce the pain, I've:
- increased timeout to 2 hours
- avoided redoing some unneeded work in situations where it looks like nothing has changed since last time.

In my test run it spent 18 seconds holding the lock after these changes.