### PR TITLE
Fix how secrets are read in the harnesses

### DIFF
--- a/evals/harnesses.py
+++ b/evals/harnesses.py
@@ -72,10 +72,12 @@ class MTBenchJudgeHarness:
 
     def generate_script(self, slurm_config, env_vars):
         # Check if OPENAI_API_KEY is set since this harness uses GPT judge models
-        if "OPENAI_API_KEY" not in env_vars or not env_vars["OPENAI_API_KEY"]:
+        openai_api_key = os.environ.get("OPENAI_API_KEY")
+        if not openai_api_key:
             raise ValueError("MTBenchJudgeHarness requires OPENAI_API_KEY environment variable to be set for GPT judge model")
-        
+
         env_vars = copy.deepcopy(env_vars)
+        env_vars["OPENAI_API_KEY"] = openai_api_key
         env_vars["LANGUAGE"] = self.language
         env_vars["JUDGE_MODEL"] = self.judge_model
         config = {}
@@ -96,13 +98,17 @@ class AlpacaEvalHarness:
 
     def generate_script(self, slurm_config, env_vars):
         # Check if OPENAI env vars are set since this harness uses GPT annotator models
-        if "OPENAI_API_KEY" not in env_vars or not env_vars["OPENAI_API_KEY"]:
+        openai_api_key = os.environ.get("OPENAI_API_KEY")
+        if not openai_api_key:
             raise ValueError("AlpacaEvalHarness requires OPENAI_API_KEY environment variable to be set for GPT annotator model")
         
-        if "OPENAI_ORG_ID" not in env_vars or not env_vars["OPENAI_ORG_ID"]:
+        openai_org_id = os.environ.get("OPENAI_ORG_ID")
+        if not openai_org_id:
             raise ValueError("AlpacaEvalHarness requires OPENAI_ORG_ID environment variable to be set for GPT annotator model")
                 
         env_vars = copy.deepcopy(env_vars)
+        env_vars["OPENAI_API_KEY"] = openai_api_key
+        env_vars["OPENAI_ORG_ID"] = openai_org_id
         env_vars["LANGUAGE"] = self.language
         env_vars["ANNOTATOR_CONFIG"] = self.annotator_config
         model_id = os.path.basename(env_vars["MODEL"])


### PR DESCRIPTION
The secrets were not read correctly and the execution of the evals that require them failed. Now they are read from env vars. If not set - terminate the job submission by raising ValueError