### PR TITLE
fix model loading and container path issues

### DIFF
--- a/evals/slurm.py
+++ b/evals/slurm.py
@@ -45,7 +45,7 @@ def read_command_log():
             for line in f.readlines():
                 entry = json.loads(line.rstrip())
                 entries[entry["job_id"]] = entry
-        return entries
+    return entries
 
 def get_jobs():
     command = ['squeue', '--me', '-o', '%i %T %j']

--- a/main.py
+++ b/main.py
@@ -115,6 +115,8 @@ def run_eval(eval_name, args):
         model, step = parse_model(args.model)
         output_dir = os.path.join(args.output_root, model, step)
 
+    output_dir = os.path.abspath(output_dir)
+
     #
     # generate slurm script
     #
@@ -139,7 +141,7 @@ def run_eval(eval_name, args):
     env_vars = {
         'MODEL': args.model,
         'TOKENIZER': args.tokenizer,
-        'OUTPUT_DIR': os.path.abspath(output_dir),
+        'OUTPUT_DIR': output_dir,
         'WORK_DIR': os.path.abspath(args.work_dir),
         'OUTPUT_FILE': output_file,
         'TRUST_REMOTE_CODE': "True" if args.trust_remote_code else "False",
@@ -152,6 +154,7 @@ def run_eval(eval_name, args):
         'LM_EVAL_REPO': lm_eval_config['LM_EVAL_REPO'],
         'LM_EVAL_REF': lm_eval_config['LM_EVAL_REF'],
         'LM_EVAL_PATH': lm_eval_config['LM_EVAL_PATH'],
+        'TRANSFORMERS_VERSION': args.transformers_version,
     }
 
     job_name = f"vllm_{eval_name}" if backend == 'vllm' else eval_name
@@ -189,8 +192,9 @@ def run_eval(eval_name, args):
         os.makedirs(args.work_dir)
     if not os.path.exists(args.log_dir):
         os.makedirs(args.log_dir)
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    if os.path.exists(output_dir) and not os.path.isdir(output_dir):
+        raise ValueError(f"Output directory path '{output_dir}' exists but is not a directory")
+    os.makedirs(output_dir, exist_ok=True)
 
     process = subprocess.run(['sbatch', script_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     if process.returncode != 0:
@@ -279,6 +283,7 @@ def main():
     parser.add_argument('--limit', type=int, help='Limit the number of examples per task (for testing purposes only)')
     parser.add_argument('--batch_size', type=str, default='', help='Batch size for inference (default: auto for vLLM, 4 for HF)')
     parser.add_argument('--lm_eval', type=str, help='lm-evaluation-harness source: URL, URL@ref, or local path (default: LumiOpen/main)')
+    parser.add_argument('--transformers_version', type=str, default='4.57.1', help='Transformers version to install in container (default: 4.57.1)')
     # slurm config
     parser.add_argument('--project', type=str, default="project_462000963", help="Project for sbatch job")
     parser.add_argument('--partition', type=str, default="small-g", help="Partition for sbatch job")

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -156,7 +156,7 @@ ${PYTHON_BIN} /tmp/tools/stage_aiter.py
 export PYTHONPATH="$HOME/.aiter/jit/install:${PYTHONPATH-}"
 
 # Install specific transformers version
-${PYTHON_BIN} -m pip install --user -q -U transformers==4.57.0
+${PYTHON_BIN} -m pip install --user -q -U transformers=={{ env_vars.TRANSFORMERS_VERSION }}
 
 # ------- get LUMI harness (puts it first on sys.path) -------
 EVAL_HARNESS_DIR="/tmp/lm-eval"

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 
 export IMG="/scratch/{{ slurm_config.account }}/containers/vllm_v10.1.1.sif"
 export PRJ="/scratch/{{ slurm_config.account }}"   # will be /project in container
-export SCR="$PWD"                          # SCR = scratch directory, will be /workspace in container
+export SCR="$(pwd -P)"                     # SCR = scratch directory, will be /workspace in container (resolve symlinks)
 export ACC="{{ slurm_config.account }}"
 
 # Parse gres for GPU count (e.g., "gpu:mi250:4" -> 4)

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -73,9 +73,6 @@ export HOME=/tmp
 PYTHON_BIN="/opt/miniconda3/envs/pytorch/bin/python"
 export PYTHON_BIN
 
-MODEL_SAFE="${MODEL_ID//\//-}"
-MODEL_LOCAL="/project/hf_cache/models/${MODEL_SAFE}"
-
 # ---- env & caches (disable xet + telemetry) ----
 export HF_HUB_DISABLE_XET=1
 export HF_HUB_ENABLE_HF_TRANSFER=0
@@ -158,6 +155,9 @@ ${PYTHON_BIN} /tmp/tools/stage_aiter.py
 
 export PYTHONPATH="$HOME/.aiter/jit/install:${PYTHONPATH-}"
 
+# Install specific transformers version
+${PYTHON_BIN} -m pip install --user -q -U transformers==4.57.0
+
 # ------- get LUMI harness (puts it first on sys.path) -------
 EVAL_HARNESS_DIR="/tmp/lm-eval"
 
@@ -211,7 +211,7 @@ FEWSHOT_AS_MULTITURN_FLAG=""
 
 {% if env_vars.BACKEND == "vllm" %}
 MODEL_BACKEND="vllm"
-MODEL_ARGS="pretrained=${MODEL_LOCAL:-${MODEL_ID}},dtype=auto,download_dir=/project/hf_cache/models,tensor_parallel_size=${TP},max_model_len=4096,gpu_memory_utilization=0.90"
+MODEL_ARGS="pretrained=${MODEL_ID},dtype=auto,download_dir=/project/hf_cache/models,tensor_parallel_size=${TP},max_model_len=4096,gpu_memory_utilization=0.90"
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${MODEL_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% endif %}
@@ -220,7 +220,7 @@ MODEL_BACKEND="dummy"
 MODEL_ARGS="pretrained={{ env_vars.MODEL }}"
 {% else %}
 MODEL_BACKEND="hf-auto"
-MODEL_ARGS="pretrained=${MODEL_LOCAL:-${MODEL_ID}},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
+MODEL_ARGS="pretrained=${MODEL_ID},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${MODEL_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% endif %}


### PR DESCRIPTION
fix model loading and container path issues:

- removed MODEL_LOCAL logic that always tried to load from non-existent local paths instead of falling back to huggingface. uncached models would fail with OSError.

- added configurable transformers install (default 4.57.1) since newer models require it. use --transformers_version to override.

- fixed crash on fresh clone when command_history.jsonl doesn't exist - read_command_log now returns empty dict instead of None.

- fixed /pfs mkdir errors by resolving symlinks in working directory. /scratch is a symlink to /pfs/lustrep2/scratch but python's abspath resolves it while bash $PWD doesn't, causing path prefix matching to fail and trying to create unmounted /pfs in container.