### PR TITLE
Add RULER Long Context Evaluation Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ command_history.jsonl
 .*.sw?
 __pycache__
 output
+test_output
 .local

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This is a script to simplify running many evals simultaneously in our slurm
 environment.  It accepts hugging face model IDs (i.e. org/modelname) or
 directory paths to models in the huggingface format.
 
+## Quick Start
+
+For common evaluation scenarios, use the pre-configured scripts:
+
+- `cpt.sh` / `cpt-vllm.sh` - Standard continuous pretraining evaluations
+- `chat.sh` - Chat model evaluations
+- `code.sh` - Code generation evaluations
+- `ruler.sh` / `ruler-vllm.sh` - **NEW:** Long context evaluations (4K-128K tokens)
+
+See [RULER_README.md](RULER_README.md) for detailed documentation on long context evaluations.
+
 ## Usage
 
 Common run configs can be found in command line scripts like `cpt.sh` which you

--- a/README.md
+++ b/README.md
@@ -13,7 +13,22 @@ For common evaluation scenarios, use the pre-configured scripts:
 - `code.sh` - Code generation evaluations
 - `ruler.sh` / `ruler-vllm.sh` - **NEW:** Long context evaluations (4K-128K tokens)
 
-See [RULER_README.md](RULER_README.md) for detailed documentation on long context evaluations.
+### RULER Long Context Evaluations
+
+RULER provides 13 distinct subtasks across 6 sequence lengths (4K-128K tokens) for comprehensive long-context evaluation:
+
+```bash
+# Quick test
+sh ruler.sh /path/to/model --subtasks "niah_single_1" --sequence-lengths "4096" --limit 10
+
+# Run all 78 combinations (13 subtasks × 6 sequence lengths)
+sh ruler-vllm.sh /path/to/model
+```
+
+**Documentation:**
+- [RULER_QUICK_REFERENCE.md](RULER_QUICK_REFERENCE.md) - Command cheat sheet
+- [RULER_README.md](RULER_README.md) - Complete documentation
+- [RULER_TESTING.md](RULER_TESTING.md) - Testing guide
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,23 +13,6 @@ For common evaluation scenarios, use the pre-configured scripts:
 - `code.sh` - Code generation evaluations
 - `ruler.sh` / `ruler-vllm.sh` - **NEW:** Long context evaluations (4K-128K tokens)
 
-### RULER Long Context Evaluations
-
-RULER provides 13 distinct subtasks across 6 sequence lengths (4K-128K tokens) for comprehensive long-context evaluation:
-
-```bash
-# Quick test
-sh ruler.sh /path/to/model --subtasks "niah_single_1" --sequence-lengths "4096" --limit 10
-
-# Run all 78 combinations (13 subtasks × 6 sequence lengths)
-sh ruler-vllm.sh /path/to/model
-```
-
-**Documentation:**
-- [RULER_QUICK_REFERENCE.md](RULER_QUICK_REFERENCE.md) - Command cheat sheet
-- [RULER_README.md](RULER_README.md) - Complete documentation
-- [RULER_TESTING.md](RULER_TESTING.md) - Testing guide
-
 ## Usage
 
 Common run configs can be found in command line scripts like `cpt.sh` which you
@@ -56,6 +39,20 @@ python main.py \
     --model path/to/model_step1234 \
     eval_name1 eval_name2
 ```
+
+### RULER Long Context Evaluations
+
+RULER evaluates models on long contexts (4K-128K tokens) with 13 subtasks:
+
+```bash
+# Quick test
+sh ruler.sh /path/to/model --subtasks "niah_single_1" --sequence-lengths "4096"
+
+# Full evaluation (78 jobs: 13 subtasks × 6 sequence lengths)
+sh ruler-vllm.sh /path/to/model
+```
+
+**See [RULER_README.md](RULER_README.md) for complete documentation, examples, and troubleshooting.**
 
 ### Backend selection
 

--- a/RULER_QUICK_REFERENCE.md
+++ b/RULER_QUICK_REFERENCE.md
@@ -14,10 +14,11 @@ NIAH (Needle in a Haystack):
   niah_multivalue, niah_multiquery
 
 Other Tasks:
-  vt    - Variable Tracking
-  cwe   - Common Words Extraction
-  fwe   - Frequent Words Extraction
-  qa_1, qa_2 - Question Answering
+  ruler_vt         - Variable Tracking
+  ruler_cwe        - Common Words Extraction
+  ruler_fwe        - Frequent Words Extraction
+  ruler_qa_hotpot  - Question Answering (Hotpot)
+  ruler_qa_squad   - Question Answering (SQuADv2)
 ```
 
 ## 6 Sequence Lengths
@@ -41,7 +42,7 @@ python main.py --model /path/to/model --limit 10 ruler_niah_single_1_4096
 ### Run Specific Subtasks at Specific Lengths
 ```bash
 sh ruler.sh /path/to/model \
-    --subtasks "niah_single_1,vt" \
+    --subtasks "niah_single_1,ruler_vt" \
     --sequence-lengths "4096,8192"
 ```
 
@@ -155,8 +156,8 @@ output/v2/<model-name>/ruler_<seqlen>.json  (for grouped)
 Example:
 ```
 output/v2/Llama-3.1-8B/ruler_niah_single_1_4096.json
-output/v2/Llama-3.1-8B/ruler_vt_8192.json
-output/v2/Llama-3.1-8B/ruler_qa_1_16384.json
+output/v2/Llama-3.1-8B/ruler_ruler_vt_8192.json
+output/v2/Llama-3.1-8B/ruler_ruler_qa_hotpot_16384.json
 ```
 
 ## How It Works

--- a/RULER_QUICK_REFERENCE.md
+++ b/RULER_QUICK_REFERENCE.md
@@ -1,0 +1,171 @@
+# RULER Quick Reference Guide
+
+## Task Naming Convention
+
+- **Individual tasks**: `ruler_<subtask>_<seqlen>` (e.g., `ruler_niah_single_1_4096`)
+- **Grouped tasks**: `ruler_<seqlen>` (e.g., `ruler_4096` runs all 13 subtasks)
+
+## 13 RULER Subtasks
+
+```
+NIAH (Needle in a Haystack):
+  niah_single_1, niah_single_2, niah_single_3
+  niah_multikey_1, niah_multikey_2, niah_multikey_3
+  niah_multivalue, niah_multiquery
+
+Other Tasks:
+  vt    - Variable Tracking
+  cwe   - Common Words Extraction
+  fwe   - Frequent Words Extraction
+  qa_1, qa_2 - Question Answering
+```
+
+## 6 Sequence Lengths
+
+```
+4096, 8192, 16384, 32768, 65536, 131072
+```
+
+## Common Commands
+
+### Test Single Task
+```bash
+python main.py --model /path/to/model ruler_niah_single_1_4096
+```
+
+### Test with Limited Samples
+```bash
+python main.py --model /path/to/model --limit 10 ruler_niah_single_1_4096
+```
+
+### Run Specific Subtasks at Specific Lengths
+```bash
+sh ruler.sh /path/to/model \
+    --subtasks "niah_single_1,vt" \
+    --sequence-lengths "4096,8192"
+```
+
+### Run All NIAH Tests
+```bash
+sh ruler.sh /path/to/model \
+    --subtasks "niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery"
+```
+
+### Run All Tasks at Short Lengths Only
+```bash
+sh ruler.sh /path/to/model --sequence-lengths "4096,8192,16384"
+```
+
+### Run Everything (78 jobs)
+```bash
+sh ruler-vllm.sh /path/to/model
+```
+
+### With Custom SLURM Config
+```bash
+sh ruler.sh /path/to/model \
+    --partition standard-g \
+    --time 24:00:00 \
+    --gres gpu:mi250:8
+```
+
+## Job Counts
+
+| Configuration | Jobs |
+|---------------|------|
+| All tasks, all lengths | 13 × 6 = 78 |
+| All NIAH, all lengths | 8 × 6 = 48 |
+| All tasks, 3 short lengths | 13 × 3 = 39 |
+| 2 tasks, 2 lengths | 2 × 2 = 4 |
+| Single task | 1 |
+
+## Monitoring
+
+```bash
+# Watch jobs
+python watch.py
+
+# Check once
+python watch.py --once
+
+# View history
+python watch.py --hist --days 3
+
+# View results
+sh summary.sh output/v2/<model-name>
+
+# List result files
+ls output/v2/<model-name>/ruler_*
+```
+
+## Backend Options
+
+```bash
+# HuggingFace (default)
+sh ruler.sh /path/to/model
+
+# vLLM (faster)
+sh ruler-vllm.sh /path/to/model
+
+# Manual with specific backend
+python main.py --model /path/to/model --backend vllm ruler_niah_single_1_4096
+```
+
+## Passing Additional Args
+
+```bash
+# Limit samples
+sh ruler.sh /path/to/model --limit 50
+
+# Custom lm-eval source
+sh ruler.sh /path/to/model --lm_eval https://github.com/EleutherAI/lm-evaluation-harness@main
+
+# Trust remote code
+sh ruler.sh /path/to/model --trust_remote_code
+```
+
+## Testing Strategy
+
+1. **Start small**: Test 1 task, 1 length, limited samples
+   ```bash
+   python main.py --model /path/to/model --limit 10 ruler_niah_single_1_4096
+   ```
+
+2. **Expand gradually**: Test 2-3 tasks at short lengths
+   ```bash
+   sh ruler.sh /path/to/model \
+       --subtasks "niah_single_1,vt" \
+       --sequence-lengths "4096,8192" \
+       --limit 50
+   ```
+
+3. **Go full scale**: Run all combinations
+   ```bash
+   sh ruler-vllm.sh /path/to/model
+   ```
+
+## Result Files
+
+Results are saved as:
+```
+output/v2/<model-name>/ruler_<subtask>_<seqlen>.json
+output/v2/<model-name>/ruler_<seqlen>.json  (for grouped)
+```
+
+Example:
+```
+output/v2/Llama-3.1-8B/ruler_niah_single_1_4096.json
+output/v2/Llama-3.1-8B/ruler_vt_8192.json
+output/v2/Llama-3.1-8B/ruler_qa_1_16384.json
+```
+
+## How It Works
+
+1. Scripts call `python main.py <task_name>`
+2. `main.py` generates a SLURM job script
+3. `main.py` submits it with `sbatch`
+4. SLURM schedules and runs the job
+5. Results are saved to output directory
+
+**The scripts do NOT run evaluations locally - they submit them to SLURM!**
+

--- a/RULER_QUICK_REFERENCE.md
+++ b/RULER_QUICK_REFERENCE.md
@@ -92,7 +92,10 @@ python watch.py --once
 # View history
 python watch.py --hist --days 3
 
-# View results
+# View RULER results summary
+sh summary_ruler.sh output/v2/<model-name>
+
+# View other benchmark results
 sh summary.sh output/v2/<model-name>
 
 # List result files

--- a/RULER_README.md
+++ b/RULER_README.md
@@ -192,11 +192,14 @@ python watch.py --hist --days 3
 ### View Results
 
 ```bash
-# View summary of all results for a model
+# View RULER summary of all results for a model
+sh summary_ruler.sh output/v2/<model-name>
+
+# View other benchmark results
 sh summary.sh output/v2/<model-name>
 
 # Results are stored in:
-# output/v2/<model-name>/<step>/ruler_<sequence_length>.json
+# output/v2/<model-name>/ruler_<subtask>_<sequence_length>.json
 ```
 
 ## Interpreting Results
@@ -290,7 +293,7 @@ sh ruler-vllm.sh /path/to/model
 python watch.py
 
 # 5. View results when complete
-sh summary.sh output/v2/<model-name>
+sh summary_ruler.sh output/v2/<model-name>
 ```
 
 ### Example 5: Specific Individual Tasks

--- a/RULER_README.md
+++ b/RULER_README.md
@@ -1,0 +1,213 @@
+# RULER Long Context Evaluation
+
+This document describes the integration of RULER (Rule-based Long-context Understanding Evaluation) benchmarks into the evaluation framework.
+
+## What is RULER?
+
+RULER is a benchmark designed to evaluate language models on their ability to handle long contexts. It tests models across various sequence lengths with different types of tasks:
+
+- **NIAH (Needle in a Haystack)**: Finding specific information within long contexts
+- **Variable Tracking**: Following variable assignments and retrieving values
+- **Common Words Extraction**: Identifying frequently occurring words
+- **Frequent Words Extraction**: Extracting the most frequent words
+- **Question Answering**: Answering questions based on information in long contexts
+
+## Supported Sequence Lengths
+
+The integration supports the following sequence lengths (powers of 2):
+
+- 4,096 tokens
+- 8,192 tokens
+- 16,384 tokens
+- 32,768 tokens (32K)
+- 65,536 tokens (64K)
+- 131,072 tokens (128K)
+
+## Usage
+
+### Running All RULER Evaluations
+
+To run all RULER evaluations across all sequence lengths:
+
+```bash
+# Using HuggingFace backend (default)
+sh ruler.sh /path/to/model
+
+# Using vLLM backend (faster, experimental)
+sh ruler-vllm.sh /path/to/model
+```
+
+### Running Specific Sequence Lengths
+
+To run evaluations for specific sequence lengths:
+
+```bash
+# Single sequence length
+python main.py --model /path/to/model ruler_4096
+
+# Multiple sequence lengths
+python main.py --model /path/to/model ruler_4096 ruler_8192 ruler_16384
+```
+
+### Custom SLURM Configuration
+
+You can customize the SLURM job parameters:
+
+```bash
+# Custom partition and time
+sh ruler.sh /path/to/model --partition standard-g --time 24:00:00
+
+# Custom GPU allocation
+sh ruler.sh /path/to/model --gres gpu:mi250:8
+```
+
+### Backend Selection
+
+Choose between different backends based on your needs:
+
+```bash
+# HuggingFace backend (default, most compatible)
+sh ruler.sh /path/to/model
+
+# vLLM backend (faster inference)
+sh ruler-vllm.sh /path/to/model
+
+# Custom model arguments for vLLM
+python main.py --model /path/to/model --backend vllm \
+    --model_args "max_model_len=32768,gpu_memory_utilization=0.95" \
+    ruler_32768
+```
+
+## Resource Requirements
+
+Different sequence lengths have different computational requirements:
+
+| Sequence Length | Recommended Time | Recommended GPUs | Memory Requirements |
+|-----------------|------------------|------------------|---------------------|
+| 4,096           | 4-8 hours        | 4 GPUs           | ~40GB               |
+| 8,192           | 8-12 hours       | 4 GPUs           | ~50GB               |
+| 16,384          | 12-16 hours      | 4-8 GPUs         | ~70GB               |
+| 32,768          | 16-24 hours      | 8 GPUs           | ~100GB              |
+| 65,536          | 24-36 hours      | 8 GPUs           | ~150GB              |
+| 131,072         | 36-48 hours      | 8 GPUs           | ~200GB              |
+
+**Note**: These are estimates and may vary based on model size and architecture.
+
+## Using Custom lm-evaluation-harness
+
+If you need to use a specific version of lm-evaluation-harness that includes RULER tasks:
+
+```bash
+# Use a specific GitHub repository and branch
+python main.py --model /path/to/model \
+    --lm_eval https://github.com/EleutherAI/lm-evaluation-harness@main \
+    ruler_4096
+
+# Use a local development version
+python main.py --model /path/to/model \
+    --lm_eval /path/to/local/lm-evaluation-harness \
+    ruler_4096
+```
+
+## Monitoring and Results
+
+### Monitor Job Status
+
+```bash
+# Watch jobs in real-time
+python watch.py
+
+# Check status once
+python watch.py --once
+
+# View job history
+python watch.py --hist --days 3
+```
+
+### View Results
+
+```bash
+# View summary of all results for a model
+sh summary.sh output/v2/<model-name>
+
+# Results are stored in:
+# output/v2/<model-name>/<step>/ruler_<sequence_length>.json
+```
+
+## Interpreting Results
+
+RULER evaluations produce accuracy scores for different task types. The overall score is an average across all subtasks. Higher scores indicate better long-context understanding:
+
+- **0.0 - 0.3**: Poor long-context handling
+- **0.3 - 0.5**: Basic long-context capabilities
+- **0.5 - 0.7**: Good long-context performance
+- **0.7 - 0.9**: Very good long-context performance
+- **0.9 - 1.0**: Excellent long-context performance
+
+## Troubleshooting
+
+### Out of Memory Errors
+
+If you encounter OOM errors:
+
+1. Reduce batch size: `--batch_size 1`
+2. Use vLLM backend with lower utilization: `--model_args "gpu_memory_utilization=0.85"`
+3. Increase GPU allocation: `--gres gpu:mi250:8`
+4. For very long sequences, consider gradient checkpointing if available
+
+### RULER Tasks Not Found
+
+If you see "Task not found" errors, ensure you're using a version of lm-evaluation-harness that includes RULER tasks:
+
+```bash
+python main.py --model /path/to/model \
+    --lm_eval https://github.com/EleutherAI/lm-evaluation-harness@main \
+    ruler_4096
+```
+
+### Very Long Run Times
+
+For the longest sequence lengths (65K, 128K), consider:
+
+1. Using vLLM backend for faster inference
+2. Running in stages (test shorter lengths first)
+3. Using `--limit` for testing: `--limit 50`
+
+## Examples
+
+### Complete Workflow
+
+```bash
+# 1. Run all RULER evaluations
+sh ruler.sh /path/to/model
+
+# 2. Monitor progress
+python watch.py
+
+# 3. View results when complete
+sh summary.sh output/v2/<model-name>
+```
+
+### Quick Test
+
+```bash
+# Test with limited samples
+python main.py --model /path/to/model --limit 10 ruler_4096
+```
+
+### Production Run
+
+```bash
+# Full evaluation with optimal settings
+sh ruler-vllm.sh org/modelname \
+    --partition standard-g \
+    --time 48:00:00 \
+    --gres gpu:mi250:8
+```
+
+## References
+
+- RULER Paper: [arXiv:2404.06654](https://arxiv.org/abs/2404.06654)
+- lm-evaluation-harness: [GitHub Repository](https://github.com/EleutherAI/lm-evaluation-harness)
+- RULER Tasks: [GitHub Directory](https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/ruler)
+

--- a/RULER_README.md
+++ b/RULER_README.md
@@ -4,13 +4,21 @@ This document describes the integration of RULER (Rule-based Long-context Unders
 
 ## What is RULER?
 
-RULER is a benchmark designed to evaluate language models on their ability to handle long contexts. It tests models across various sequence lengths with different types of tasks:
+RULER is a benchmark designed to evaluate language models on their ability to handle long contexts. It includes **13 distinct subtasks** that test different aspects of long-context understanding:
 
-- **NIAH (Needle in a Haystack)**: Finding specific information within long contexts
-- **Variable Tracking**: Following variable assignments and retrieving values
-- **Common Words Extraction**: Identifying frequently occurring words
-- **Frequent Words Extraction**: Extracting the most frequent words
-- **Question Answering**: Answering questions based on information in long contexts
+### NIAH (Needle in a Haystack) - 8 variants
+- **niah_single_1, niah_single_2, niah_single_3**: Finding specific information within long contexts
+- **niah_multikey_1, niah_multikey_2, niah_multikey_3**: Finding multiple related pieces of information
+- **niah_multivalue**: Retrieving multiple values for the same key
+- **niah_multiquery**: Answering multiple queries about the same context
+
+### Other Tasks - 5 types
+- **vt**: Variable Tracking - Following variable assignments and retrieving values
+- **cwe**: Common Words Extraction - Identifying frequently occurring words
+- **fwe**: Frequent Words Extraction - Extracting the most frequent words
+- **qa_1, qa_2**: Question Answering - Comprehension questions based on long contexts
+
+Each subtask is evaluated independently at each sequence length, allowing fine-grained analysis of model capabilities.
 
 ## Supported Sequence Lengths
 
@@ -23,30 +31,76 @@ The integration supports the following sequence lengths (powers of 2):
 - 65,536 tokens (64K)
 - 131,072 tokens (128K)
 
+## Task Structure
+
+The integration provides two modes:
+
+1. **Granular Mode** (Recommended): Run individual subtasks at specific sequence lengths
+   - Task format: `ruler_<subtask>_<seqlen>` (e.g., `ruler_niah_single_1_4096`)
+   - 13 subtasks × 6 sequence lengths = **78 individual tasks**
+   - Each task runs as a separate SLURM job
+   - Allows parallel execution and fine-grained resource management
+
+2. **Grouped Mode**: Run all subtasks at once for a sequence length
+   - Task format: `ruler_<seqlen>` (e.g., `ruler_4096`)
+   - All 13 subtasks run in a single job
+
 ## Usage
 
-### Running All RULER Evaluations
+### Running All RULER Evaluations (78 jobs)
 
-To run all RULER evaluations across all sequence lengths:
+To run all subtasks at all sequence lengths (submits 78 SLURM jobs):
 
 ```bash
-# Using HuggingFace backend (default)
+# Using HuggingFace backend
 sh ruler.sh /path/to/model
 
 # Using vLLM backend (faster, experimental)
 sh ruler-vllm.sh /path/to/model
 ```
 
-### Running Specific Sequence Lengths
+### Running Specific Subtasks
 
-To run evaluations for specific sequence lengths:
+To run only certain subtasks across all or selected sequence lengths:
 
 ```bash
-# Single sequence length
-python main.py --model /path/to/model ruler_4096
+# Specific subtasks at all sequence lengths
+sh ruler.sh /path/to/model --subtasks "niah_single_1,vt,qa_1"
 
-# Multiple sequence lengths
-python main.py --model /path/to/model ruler_4096 ruler_8192 ruler_16384
+# Specific subtasks at specific sequence lengths
+sh ruler.sh /path/to/model --subtasks "niah_single_1,vt" --sequence-lengths "4096,8192"
+
+# With vLLM backend
+sh ruler-vllm.sh /path/to/model --subtasks "niah_single_1,niah_single_2" --sequence-lengths "4096,8192,16384"
+```
+
+### Running Specific Sequence Lengths
+
+To run all subtasks at only certain sequence lengths:
+
+```bash
+# All subtasks at specific sequence lengths
+sh ruler.sh /path/to/model --sequence-lengths "4096,8192,16384"
+
+# Submits 13 × 3 = 39 jobs
+```
+
+### Running Individual Tasks
+
+To run specific individual task combinations:
+
+```bash
+# Single specific task
+python main.py --model /path/to/model ruler_niah_single_1_4096
+
+# Multiple specific tasks
+python main.py --model /path/to/model \
+    ruler_niah_single_1_4096 \
+    ruler_vt_4096 \
+    ruler_qa_1_8192
+
+# Grouped task (all subtasks at one sequence length)
+python main.py --model /path/to/model ruler_4096
 ```
 
 ### Custom SLURM Configuration
@@ -59,7 +113,17 @@ sh ruler.sh /path/to/model --partition standard-g --time 24:00:00
 
 # Custom GPU allocation
 sh ruler.sh /path/to/model --gres gpu:mi250:8
+
+# Combine multiple options
+sh ruler-vllm.sh /path/to/model \
+    --subtasks "niah_single_1,vt" \
+    --sequence-lengths "4096,8192" \
+    --partition standard-g \
+    --time 12:00:00 \
+    --gres gpu:mi250:8
 ```
+
+**Important**: The scripts call `python main.py`, which internally generates SLURM job scripts and submits them using `sbatch`. Each call to `main.py` results in a separate SLURM job being queued. The scripts do NOT run the evaluations directly - they submit them to your HPC's SLURM scheduler.
 
 ### Backend Selection
 
@@ -175,30 +239,75 @@ For the longest sequence lengths (65K, 128K), consider:
 
 ## Examples
 
-### Complete Workflow
+### Example 1: Quick Test with Few Subtasks
+
+Test a few subtasks with limited samples:
 
 ```bash
-# 1. Run all RULER evaluations
-sh ruler.sh /path/to/model
+# Test 2 subtasks at 2 sequence lengths (4 jobs total)
+sh ruler.sh /path/to/model \
+    --subtasks "niah_single_1,vt" \
+    --sequence-lengths "4096,8192" \
+    --limit 10
+```
 
-# 2. Monitor progress
+### Example 2: Full NIAH Evaluation
+
+Run all Needle in a Haystack variants at all sequence lengths:
+
+```bash
+# 8 NIAH subtasks × 6 sequence lengths = 48 jobs
+sh ruler-vllm.sh /path/to/model \
+    --subtasks "niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery"
+```
+
+### Example 3: Evaluate Short Context Lengths Only
+
+Test all subtasks but only at shorter sequence lengths:
+
+```bash
+# 13 subtasks × 3 sequence lengths = 39 jobs
+sh ruler.sh /path/to/model --sequence-lengths "4096,8192,16384"
+```
+
+### Example 4: Complete Workflow
+
+```bash
+# 1. Start by testing a small subset
+sh ruler.sh /path/to/model \
+    --subtasks "niah_single_1" \
+    --sequence-lengths "4096" \
+    --limit 10
+
+# 2. Monitor to ensure it works
+python watch.py --once
+
+# 3. Once confirmed, run all evaluations (78 jobs)
+sh ruler-vllm.sh /path/to/model
+
+# 4. Monitor progress
 python watch.py
 
-# 3. View results when complete
+# 5. View results when complete
 sh summary.sh output/v2/<model-name>
 ```
 
-### Quick Test
+### Example 5: Specific Individual Tasks
+
+Run only specific task combinations manually:
 
 ```bash
-# Test with limited samples
-python main.py --model /path/to/model --limit 10 ruler_4096
+# Run 3 specific tasks
+python main.py --model /path/to/model \
+    ruler_niah_single_1_4096 \
+    ruler_vt_8192 \
+    ruler_qa_1_16384
 ```
 
-### Production Run
+### Example 6: Production Run with Optimal Settings
 
 ```bash
-# Full evaluation with optimal settings
+# Full evaluation with custom SLURM settings
 sh ruler-vllm.sh org/modelname \
     --partition standard-g \
     --time 48:00:00 \

--- a/RULER_README.md
+++ b/RULER_README.md
@@ -2,6 +2,30 @@
 
 This document describes the integration of RULER (Rule-based Long-context Understanding Evaluation) benchmarks into the evaluation framework.
 
+## Quick Reference
+
+ruler.sh and ruler-vllm.sh are interchangeble in the command line. They just run different backends. 
+
+```bash
+# Run specific subtasks at specific lengths
+sh ruler.sh /path/to/model --subtasks "niah_single_1,ruler_vt" --sequence-lengths "4096,8192"
+
+# Run all NIAH tests at all lengths (48 jobs)
+sh ruler.sh /path/to/model --subtasks "niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery"
+
+# Run everything (78 jobs)
+sh ruler-vllm.sh /path/to/model
+
+# View results
+sh summary_ruler.sh output/v2/<model-name>
+```
+
+**13 Subtasks:** `niah_single_1`, `niah_single_2`, `niah_single_3`, `niah_multikey_1`, `niah_multikey_2`, `niah_multikey_3`, `niah_multivalue`, `niah_multiquery`, `ruler_vt`, `ruler_cwe`, `ruler_fwe`, `ruler_qa_hotpot`, `ruler_qa_squad`
+
+**6 Sequence Lengths:** 4096, 8192, 16384, 32768, 65536, 131072
+
+---
+
 ## What is RULER?
 
 RULER is a benchmark designed to evaluate language models on their ability to handle long contexts. It includes **13 distinct subtasks** that test different aspects of long-context understanding:
@@ -37,7 +61,7 @@ The integration supports the following sequence lengths (powers of 2):
 The integration provides two modes:
 
 1. **Granular Mode** (Recommended): Run individual subtasks at specific sequence lengths
-   - Task format: `ruler_<subtask>_<seqlen>` (e.g., `ruler_niah_single_1_4096`)
+   - Task format: Run ruler subtask on given sequence length
    - 13 subtasks × 6 sequence lengths = **78 individual tasks**
    - Each task runs as a separate SLURM job
    - Allows parallel execution and fine-grained resource management
@@ -86,24 +110,6 @@ sh ruler.sh /path/to/model --sequence-lengths "4096,8192,16384"
 # Submits 13 × 3 = 39 jobs
 ```
 
-### Running Individual Tasks
-
-To run specific individual task combinations:
-
-```bash
-# Single specific task
-python main.py --model /path/to/model ruler_niah_single_1_4096
-
-# Multiple specific tasks
-python main.py --model /path/to/model \
-    ruler_niah_single_1_4096 \
-    ruler_ruler_vt_4096 \
-    ruler_ruler_qa_hotpot_8192
-
-# Grouped task (all subtasks at one sequence length)
-python main.py --model /path/to/model ruler_4096
-```
-
 ### Custom SLURM Configuration
 
 You can customize the SLURM job parameters:
@@ -124,7 +130,7 @@ sh ruler-vllm.sh /path/to/model \
     --gres gpu:mi250:8
 ```
 
-**Important**: The scripts call `python main.py`, which internally generates SLURM job scripts and submits them using `sbatch`. Each call to `main.py` results in a separate SLURM job being queued. The scripts do NOT run the evaluations directly - they submit them to your HPC's SLURM scheduler.
+**Important**: Scripts submit SLURM jobs via `python main.py` → `sbatch`. They don't run evaluations locally.
 
 ### Backend Selection
 
@@ -137,41 +143,6 @@ sh ruler.sh /path/to/model
 # vLLM backend (faster inference)
 sh ruler-vllm.sh /path/to/model
 
-# Custom model arguments for vLLM
-python main.py --model /path/to/model --backend vllm \
-    --model_args "max_model_len=32768,gpu_memory_utilization=0.95" \
-    ruler_32768
-```
-
-## Resource Requirements
-
-Different sequence lengths have different computational requirements:
-
-| Sequence Length | Recommended Time | Recommended GPUs | Memory Requirements |
-|-----------------|------------------|------------------|---------------------|
-| 4,096           | 4-8 hours        | 4 GPUs           | ~40GB               |
-| 8,192           | 8-12 hours       | 4 GPUs           | ~50GB               |
-| 16,384          | 12-16 hours      | 4-8 GPUs         | ~70GB               |
-| 32,768          | 16-24 hours      | 8 GPUs           | ~100GB              |
-| 65,536          | 24-36 hours      | 8 GPUs           | ~150GB              |
-| 131,072         | 36-48 hours      | 8 GPUs           | ~200GB              |
-
-**Note**: These are estimates and may vary based on model size and architecture.
-
-## Using Custom lm-evaluation-harness
-
-If you need to use a specific version of lm-evaluation-harness that includes RULER tasks:
-
-```bash
-# Use a specific GitHub repository and branch
-python main.py --model /path/to/model \
-    --lm_eval https://github.com/EleutherAI/lm-evaluation-harness@main \
-    ruler_4096
-
-# Use a local development version
-python main.py --model /path/to/model \
-    --lm_eval /path/to/local/lm-evaluation-harness \
-    ruler_4096
 ```
 
 ## Monitoring and Results
@@ -192,54 +163,17 @@ python watch.py --hist --days 3
 ### View Results
 
 ```bash
-# View RULER summary of all results for a model
+# RULER-specific summary (recommended for RULER results)
 sh summary_ruler.sh output/v2/<model-name>
 
-# View other benchmark results
+# General benchmark summary (for non-RULER benchmarks)
 sh summary.sh output/v2/<model-name>
 
-# Results are stored in:
-# output/v2/<model-name>/ruler_<subtask>_<sequence_length>.json
+# List individual result files
+ls output/v2/<model-name>/ruler_*.json
 ```
 
-## Interpreting Results
-
-RULER evaluations produce accuracy scores for different task types. The overall score is an average across all subtasks. Higher scores indicate better long-context understanding:
-
-- **0.0 - 0.3**: Poor long-context handling
-- **0.3 - 0.5**: Basic long-context capabilities
-- **0.5 - 0.7**: Good long-context performance
-- **0.7 - 0.9**: Very good long-context performance
-- **0.9 - 1.0**: Excellent long-context performance
-
-## Troubleshooting
-
-### Out of Memory Errors
-
-If you encounter OOM errors:
-
-1. Reduce batch size: `--batch_size 1`
-2. Use vLLM backend with lower utilization: `--model_args "gpu_memory_utilization=0.85"`
-3. Increase GPU allocation: `--gres gpu:mi250:8`
-4. For very long sequences, consider gradient checkpointing if available
-
-### RULER Tasks Not Found
-
-If you see "Task not found" errors, ensure you're using a version of lm-evaluation-harness that includes RULER tasks:
-
-```bash
-python main.py --model /path/to/model \
-    --lm_eval https://github.com/EleutherAI/lm-evaluation-harness@main \
-    ruler_4096
-```
-
-### Very Long Run Times
-
-For the longest sequence lengths (65K, 128K), consider:
-
-1. Using vLLM backend for faster inference
-2. Running in stages (test shorter lengths first)
-3. Using `--limit` for testing: `--limit 50`
+Result files are named: `ruler_<subtask>_<seqlen>.json` or `vllm_ruler_<subtask>_<seqlen>.json`
 
 ## Examples
 
@@ -250,9 +184,8 @@ Test a few subtasks with limited samples:
 ```bash
 # Test 2 subtasks at 2 sequence lengths (4 jobs total)
 sh ruler.sh /path/to/model \
-    --subtasks "niah_single_1,vt" \
+    --subtasks "niah_single_1,ruler_vt" \
     --sequence-lengths "4096,8192" \
-    --limit 10
 ```
 
 ### Example 2: Full NIAH Evaluation
@@ -281,7 +214,6 @@ sh ruler.sh /path/to/model --sequence-lengths "4096,8192,16384"
 sh ruler.sh /path/to/model \
     --subtasks "niah_single_1" \
     --sequence-lengths "4096" \
-    --limit 10
 
 # 2. Monitor to ensure it works
 python watch.py --once
@@ -294,28 +226,6 @@ python watch.py
 
 # 5. View results when complete
 sh summary_ruler.sh output/v2/<model-name>
-```
-
-### Example 5: Specific Individual Tasks
-
-Run only specific task combinations manually:
-
-```bash
-# Run 3 specific tasks
-python main.py --model /path/to/model \
-    ruler_niah_single_1_4096 \
-    ruler_ruler_vt_8192 \
-    ruler_ruler_qa_hotpot_16384
-```
-
-### Example 6: Production Run with Optimal Settings
-
-```bash
-# Full evaluation with custom SLURM settings
-sh ruler-vllm.sh org/modelname \
-    --partition standard-g \
-    --time 48:00:00 \
-    --gres gpu:mi250:8
 ```
 
 ## References

--- a/RULER_README.md
+++ b/RULER_README.md
@@ -13,10 +13,11 @@ RULER is a benchmark designed to evaluate language models on their ability to ha
 - **niah_multiquery**: Answering multiple queries about the same context
 
 ### Other Tasks - 5 types
-- **vt**: Variable Tracking - Following variable assignments and retrieving values
-- **cwe**: Common Words Extraction - Identifying frequently occurring words
-- **fwe**: Frequent Words Extraction - Extracting the most frequent words
-- **qa_1, qa_2**: Question Answering - Comprehension questions based on long contexts
+- **ruler_vt**: Variable Tracking - Following variable assignments and retrieving values
+- **ruler_cwe**: Common Words Extraction - Identifying frequently occurring words
+- **ruler_fwe**: Frequent Words Extraction - Extracting the most frequent words
+- **ruler_qa_hotpot**: Question Answering - Comprehension questions based on Hotpot dataset
+- **ruler_qa_squad**: Question Answering - Comprehension questions based on SQuADv2 dataset
 
 Each subtask is evaluated independently at each sequence length, allowing fine-grained analysis of model capabilities.
 
@@ -65,10 +66,10 @@ To run only certain subtasks across all or selected sequence lengths:
 
 ```bash
 # Specific subtasks at all sequence lengths
-sh ruler.sh /path/to/model --subtasks "niah_single_1,vt,qa_1"
+sh ruler.sh /path/to/model --subtasks "niah_single_1,ruler_vt,ruler_qa_hotpot"
 
 # Specific subtasks at specific sequence lengths
-sh ruler.sh /path/to/model --subtasks "niah_single_1,vt" --sequence-lengths "4096,8192"
+sh ruler.sh /path/to/model --subtasks "niah_single_1,ruler_vt" --sequence-lengths "4096,8192"
 
 # With vLLM backend
 sh ruler-vllm.sh /path/to/model --subtasks "niah_single_1,niah_single_2" --sequence-lengths "4096,8192,16384"
@@ -96,8 +97,8 @@ python main.py --model /path/to/model ruler_niah_single_1_4096
 # Multiple specific tasks
 python main.py --model /path/to/model \
     ruler_niah_single_1_4096 \
-    ruler_vt_4096 \
-    ruler_qa_1_8192
+    ruler_ruler_vt_4096 \
+    ruler_ruler_qa_hotpot_8192
 
 # Grouped task (all subtasks at one sequence length)
 python main.py --model /path/to/model ruler_4096
@@ -300,8 +301,8 @@ Run only specific task combinations manually:
 # Run 3 specific tasks
 python main.py --model /path/to/model \
     ruler_niah_single_1_4096 \
-    ruler_vt_8192 \
-    ruler_qa_1_16384
+    ruler_ruler_vt_8192 \
+    ruler_ruler_qa_hotpot_16384
 ```
 
 ### Example 6: Production Run with Optimal Settings

--- a/cpt-vllm.sh
+++ b/cpt-vllm.sh
@@ -25,7 +25,7 @@ run() {
   local tasks=( "$@" )
 
   # Build args as an array to keep quoting correct
-  local args=( python main.py --backend "$BACKEND" --project "$PROJECT" --partition "$QUEUE" --model "$MODEL" --time "$t" )
+  local args=( python3 main.py --backend "$BACKEND" --project "$PROJECT" --partition "$QUEUE" --model "$MODEL" --time "$t" )
 
   # Only pass --gres if explicitly provided
   if [[ -n "$CPT_GRES" ]]; then

--- a/cpt-vllm.sh
+++ b/cpt-vllm.sh
@@ -25,7 +25,7 @@ run() {
   local tasks=( "$@" )
 
   # Build args as an array to keep quoting correct
-  local args=( python3 main.py --backend "$BACKEND" --project "$PROJECT" --partition "$QUEUE" --model "$MODEL" --time "$t" )
+  local args=( python3 main.py --backend "$BACKEND" --project "$PROJECT" --partition "$QUEUE" --time "$t" )
 
   # Only pass --gres if explicitly provided
   if [[ -n "$CPT_GRES" ]]; then
@@ -36,12 +36,12 @@ run() {
     args+=( --model_args "$MODEL_ARGS" )
   fi
   if [[ -n "$APPLY_CHAT_TEMPLATE" ]]; then
-    args+=( --apply_chat_template "$APPLY_CHAT_TEMPLATE" )
+    args+=( --apply_chat_template )
   fi
   if [[ -n "$FEWSHOT_AS_MULTITURN" ]]; then
-    args+=( --fewshot_as_multiturn "$FEWSHOT_AS_MULTITURN" )
+    args+=( --fewshot_as_multiturn )
   fi
-
+  args+=( --model "$MODEL" )
   args+=( "${tasks[@]}" )
 
   printf '==> '; printf '%q ' "${args[@]}"; printf '\n'

--- a/cpt.sh
+++ b/cpt.sh
@@ -2,7 +2,7 @@ QUEUE=standard-g
 PROJECT=project_462000963
 
 # this can go very long in models that are not good at this language, i guess?
-python main.py --time 12:00:00 --project $PROJECT --partition $QUEUE --model $1 flores200_trans_en_fi flores200_trans_fi_en
-python main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 arc_challenge arc_challenge_mt_fi truthfulqa_mc truthfulqa_mc_mt_fi goldenswag_mt_fi
-python main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 mmlu mmlu_mt_fi
-python main.py --time 48:00:00 --project $PROJECT --partition $QUEUE --model $1 gsm8k gsm8k_mt_fi hellaswag hellaswag_mt_fi goldenswag
+python3 main.py --time 12:00:00 --project $PROJECT --partition $QUEUE --model $1 flores200_trans_en_fi flores200_trans_fi_en
+python3 main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 arc_challenge arc_challenge_mt_fi truthfulqa_mc truthfulqa_mc_mt_fi goldenswag_mt_fi
+python3 main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 mmlu mmlu_mt_fi
+python3 main.py --time 48:00:00 --project $PROJECT --partition $QUEUE --model $1 gsm8k gsm8k_mt_fi hellaswag hellaswag_mt_fi goldenswag

--- a/evals/evals.py
+++ b/evals/evals.py
@@ -145,28 +145,50 @@ class RulerConfig(EvalConfig):
     
     RULER (Rule-based Long-context Understanding Evaluation) evaluates models
     on their ability to retrieve and use information from long contexts.
+    
+    RULER includes 13 subtasks:
+    - niah_single_1, niah_single_2, niah_single_3 (Needle in a Haystack - single)
+    - niah_multikey_1, niah_multikey_2, niah_multikey_3 (NIAH - multiple keys)
+    - niah_multivalue (NIAH - multiple values)
+    - niah_multiquery (NIAH - multiple queries)
+    - vt (Variable Tracking)
+    - cwe (Common Words Extraction)
+    - fwe (Frequent Words Extraction)
+    - qa_1, qa_2 (Question Answering)
     """
-    def __init__(self, sequence_length, num_fewshot=0):
-        # RULER task group includes multiple subtasks:
-        # - niah_* (Needle in a Haystack)
-        # - vt (Variable Tracking)
-        # - cwe (Common Words Extraction)
-        # - fwe (Frequent Words Extraction)
-        # - qa_* (Question Answering)
-        task_name = f"ruler_{sequence_length}"
-        super().__init__(task_name, "custom", LMEvalHarness([task_name], num_fewshot=num_fewshot))
+    def __init__(self, sequence_length, subtask=None, num_fewshot=0):
+        """
+        Args:
+            sequence_length: Context length (4096, 8192, 16384, 32768, 65536, 131072)
+            subtask: Specific RULER subtask name (e.g., 'niah_single_1', 'vt', 'qa_1')
+                    If None, runs all subtasks for this sequence length
+            num_fewshot: Number of few-shot examples
+        """
         self.sequence_length = sequence_length
+        self.subtask = subtask
         self.num_fewshot = num_fewshot
+        
+        if subtask:
+            # Individual subtask
+            task_name = f"ruler_{subtask}_{sequence_length}"
+            lm_task_name = f"ruler:{sequence_length}:{subtask}"
+        else:
+            # All subtasks for this sequence length
+            task_name = f"ruler_{sequence_length}"
+            lm_task_name = f"ruler:{sequence_length}"
+        
+        super().__init__(task_name, "custom", LMEvalHarness([lm_task_name], num_fewshot=num_fewshot))
 
     def get_results_custom(self, json_data):
-        # Average score across all RULER subtasks
+        # Get score for this specific task or average across all subtasks
         if "results" not in json_data:
             return 0.0
         
-        # Collect all RULER task results
+        # Collect relevant task results
         ruler_scores = []
         for task_name, task_results in json_data["results"].items():
-            if task_name.startswith("ruler_"):
+            # Match tasks that contain our sequence length
+            if f"{self.sequence_length}" in task_name or task_name.startswith("ruler"):
                 # Try different result keys that might be present
                 if "acc,none" in task_results:
                     ruler_scores.append(task_results["acc,none"])
@@ -424,6 +446,10 @@ evals = {
 
     # RULER long context evaluations
     # Sequence lengths: powers of 2 from 4096 to 131072 (128K)
+    # Format: ruler_<subtask>_<seqlen> for individual subtasks
+    #         ruler_<seqlen> for all subtasks at that sequence length
+    
+    # Grouped tasks (all subtasks per sequence length)
     "ruler_4096": RulerConfig(sequence_length=4096, num_fewshot=0),
     "ruler_8192": RulerConfig(sequence_length=8192, num_fewshot=0),
     "ruler_16384": RulerConfig(sequence_length=16384, num_fewshot=0),
@@ -431,3 +457,28 @@ evals = {
     "ruler_65536": RulerConfig(sequence_length=65536, num_fewshot=0),
     "ruler_131072": RulerConfig(sequence_length=131072, num_fewshot=0),
 }
+
+# Generate individual RULER subtask entries for each sequence length
+# 13 subtasks × 6 sequence lengths = 78 total task combinations
+_RULER_SUBTASKS = [
+    "niah_single_1",
+    "niah_single_2", 
+    "niah_single_3",
+    "niah_multikey_1",
+    "niah_multikey_2",
+    "niah_multikey_3",
+    "niah_multivalue",
+    "niah_multiquery",
+    "vt",
+    "cwe",
+    "fwe",
+    "qa_1",
+    "qa_2",
+]
+
+_RULER_SEQUENCE_LENGTHS = [4096, 8192, 16384, 32768, 65536, 131072]
+
+for subtask in _RULER_SUBTASKS:
+    for seqlen in _RULER_SEQUENCE_LENGTHS:
+        task_key = f"ruler_{subtask}_{seqlen}"
+        evals[task_key] = RulerConfig(sequence_length=seqlen, subtask=subtask, num_fewshot=0)

--- a/evals/evals.py
+++ b/evals/evals.py
@@ -168,16 +168,20 @@ class RulerConfig(EvalConfig):
         self.subtask = subtask
         self.num_fewshot = num_fewshot
         
+        # RULER tasks use the "ruler" task name with metadata for sequence length
+        # Individual subtasks are specified via task name patterns
         if subtask:
-            # Individual subtask
+            # Individual subtask - each subtask is a separate task in RULER
+            # Task format in lm-eval is: ruler_niah_single_1, ruler_vt, ruler_qa_1, etc.
             task_name = f"ruler_{subtask}_{sequence_length}"
-            lm_task_name = f"ruler:{sequence_length}:{subtask}"
+            lm_task_name = f"ruler_{subtask}"
         else:
-            # All subtasks for this sequence length
+            # All subtasks for this sequence length (run all RULER tests)
             task_name = f"ruler_{sequence_length}"
-            lm_task_name = f"ruler:{sequence_length}"
+            lm_task_name = "ruler"
         
-        super().__init__(task_name, "custom", LMEvalHarness([lm_task_name], num_fewshot=num_fewshot))
+        super().__init__(task_name, "custom", LMEvalHarness([lm_task_name], num_fewshot=num_fewshot, 
+                                                             metadata={"max_seq_lengths": [sequence_length]}))
 
     def get_results_custom(self, json_data):
         # Get score for this specific task or average across all subtasks

--- a/evals/evals.py
+++ b/evals/evals.py
@@ -140,6 +140,47 @@ class MultiIFConfig(EvalConfig):
             return json_data["results"]["english_average"]
         return 0.0
 
+class RulerConfig(EvalConfig):
+    """Configuration for RULER long context evaluation tasks.
+    
+    RULER (Rule-based Long-context Understanding Evaluation) evaluates models
+    on their ability to retrieve and use information from long contexts.
+    """
+    def __init__(self, sequence_length, num_fewshot=0):
+        # RULER task group includes multiple subtasks:
+        # - niah_* (Needle in a Haystack)
+        # - vt (Variable Tracking)
+        # - cwe (Common Words Extraction)
+        # - fwe (Frequent Words Extraction)
+        # - qa_* (Question Answering)
+        task_name = f"ruler_{sequence_length}"
+        super().__init__(task_name, "custom", LMEvalHarness([task_name], num_fewshot=num_fewshot))
+        self.sequence_length = sequence_length
+        self.num_fewshot = num_fewshot
+
+    def get_results_custom(self, json_data):
+        # Average score across all RULER subtasks
+        if "results" not in json_data:
+            return 0.0
+        
+        # Collect all RULER task results
+        ruler_scores = []
+        for task_name, task_results in json_data["results"].items():
+            if task_name.startswith("ruler_"):
+                # Try different result keys that might be present
+                if "acc,none" in task_results:
+                    ruler_scores.append(task_results["acc,none"])
+                elif "acc" in task_results:
+                    ruler_scores.append(task_results["acc"])
+                elif "exact_match,none" in task_results:
+                    ruler_scores.append(task_results["exact_match,none"])
+                elif "exact_match" in task_results:
+                    ruler_scores.append(task_results["exact_match"])
+        
+        if ruler_scores:
+            return sum(ruler_scores) / len(ruler_scores)
+        return 0.0
+
 
 
 evals = {
@@ -380,4 +421,13 @@ evals = {
     "alpaca_eval_en": AlpacaEvalConfig(language="en"),
     "alpaca_eval_fi": AlpacaEvalConfig(language="fi"),
     "multi_if": MultiIFConfig(),
+
+    # RULER long context evaluations
+    # Sequence lengths: powers of 2 from 4096 to 131072 (128K)
+    "ruler_4096": RulerConfig(sequence_length=4096, num_fewshot=0),
+    "ruler_8192": RulerConfig(sequence_length=8192, num_fewshot=0),
+    "ruler_16384": RulerConfig(sequence_length=16384, num_fewshot=0),
+    "ruler_32768": RulerConfig(sequence_length=32768, num_fewshot=0),
+    "ruler_65536": RulerConfig(sequence_length=65536, num_fewshot=0),
+    "ruler_131072": RulerConfig(sequence_length=131072, num_fewshot=0),
 }

--- a/evals/evals.py
+++ b/evals/evals.py
@@ -151,10 +151,11 @@ class RulerConfig(EvalConfig):
     - niah_multikey_1, niah_multikey_2, niah_multikey_3 (NIAH - multiple keys)
     - niah_multivalue (NIAH - multiple values)
     - niah_multiquery (NIAH - multiple queries)
-    - vt (Variable Tracking)
-    - cwe (Common Words Extraction)
-    - fwe (Frequent Words Extraction)
-    - qa_1, qa_2 (Question Answering)
+    - ruler_vt (Variable Tracking)
+    - ruler_cwe (Common Words Extraction)
+    - ruler_fwe (Frequent Words Extraction)
+    - ruler_qa_hotpot (QA - Hotpot)
+    - ruler_qa_squad (QA - SQuADv2)
     """
     def __init__(self, sequence_length, subtask=None, num_fewshot=0):
         """
@@ -168,13 +169,14 @@ class RulerConfig(EvalConfig):
         self.subtask = subtask
         self.num_fewshot = num_fewshot
         
-        # RULER tasks use the "ruler" task name with metadata for sequence length
-        # Individual subtasks are specified via task name patterns
+        # RULER tasks: individual subtask names are used directly (niah_single_1, vt, qa_1, etc.)
+        # The task name "ruler" runs all subtasks
+        # Sequence length is controlled via metadata
         if subtask:
-            # Individual subtask - each subtask is a separate task in RULER
-            # Task format in lm-eval is: ruler_niah_single_1, ruler_vt, ruler_qa_1, etc.
-            task_name = f"ruler_{subtask}_{sequence_length}"
-            lm_task_name = f"ruler_{subtask}"
+            # Individual subtask - task names are just the subtask names
+            # e.g., "niah_single_1", "vt", "qa_1"
+            task_name = f"ruler_{subtask}_{sequence_length}"  # Internal name for our tracking
+            lm_task_name = subtask  # Actual task name for lm-eval
         else:
             # All subtasks for this sequence length (run all RULER tests)
             task_name = f"ruler_{sequence_length}"
@@ -464,6 +466,7 @@ evals = {
 
 # Generate individual RULER subtask entries for each sequence length
 # 13 subtasks × 6 sequence lengths = 78 total task combinations
+# Task names from: https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/ruler#tasks
 _RULER_SUBTASKS = [
     "niah_single_1",
     "niah_single_2", 
@@ -473,11 +476,11 @@ _RULER_SUBTASKS = [
     "niah_multikey_3",
     "niah_multivalue",
     "niah_multiquery",
-    "vt",
-    "cwe",
-    "fwe",
-    "qa_1",
-    "qa_2",
+    "ruler_vt",       # Variable tracking
+    "ruler_cwe",      # Common words extraction
+    "ruler_fwe",      # Frequent words extraction
+    "ruler_qa_hotpot",  # QA Hotpot
+    "ruler_qa_squad",   # QA SQuADv2
 ]
 
 _RULER_SEQUENCE_LENGTHS = [4096, 8192, 16384, 32768, 65536, 131072]

--- a/evals/harnesses.py
+++ b/evals/harnesses.py
@@ -18,12 +18,24 @@ class LMEvalHarness:
         env_vars["BACKEND"] = backend
         
         # Add metadata for RULER tasks
+        # Only set MAX_SEQ_LENGTH for actual RULER tasks to avoid affecting other tasks
+        is_ruler_task = any(
+            task.startswith("ruler") or 
+            task.startswith("niah_") or 
+            task in ["niah_single_1", "niah_single_2", "niah_single_3",
+                     "niah_multikey_1", "niah_multikey_2", "niah_multikey_3",
+                     "niah_multivalue", "niah_multiquery"]
+            for task in self.task_list
+        )
+        
         if self.metadata:
             import json
             env_vars["TASK_METADATA"] = json.dumps(self.metadata)
-            # Extract max_seq_lengths for model args
-            if "max_seq_lengths" in self.metadata and self.metadata["max_seq_lengths"]:
+            # Extract max_seq_lengths for model args - ONLY for RULER tasks
+            if is_ruler_task and "max_seq_lengths" in self.metadata and self.metadata["max_seq_lengths"]:
                 env_vars["MAX_SEQ_LENGTH"] = str(self.metadata["max_seq_lengths"][0])
+            else:
+                env_vars["MAX_SEQ_LENGTH"] = ""
         else:
             env_vars["TASK_METADATA"] = ""
             env_vars["MAX_SEQ_LENGTH"] = ""

--- a/evals/harnesses.py
+++ b/evals/harnesses.py
@@ -5,9 +5,10 @@ import os
 
 
 class LMEvalHarness:
-    def __init__(self, task_list, num_fewshot=0):
+    def __init__(self, task_list, num_fewshot=0, metadata=None):
         self.task_list = task_list
         self.num_fewshot = num_fewshot
+        self.metadata = metadata or {}
         self.harness = self # TODO remove
 
     def generate_script(self, slurm_config, env_vars, backend='hf'):
@@ -15,6 +16,18 @@ class LMEvalHarness:
         env_vars["TASK_LIST"] = ",".join(self.task_list)
         env_vars["NUM_FEWSHOT"] = self.num_fewshot
         env_vars["BACKEND"] = backend
+        
+        # Add metadata for RULER tasks
+        if self.metadata:
+            import json
+            env_vars["TASK_METADATA"] = json.dumps(self.metadata)
+            # Extract max_seq_lengths for model args
+            if "max_seq_lengths" in self.metadata and self.metadata["max_seq_lengths"]:
+                env_vars["MAX_SEQ_LENGTH"] = str(self.metadata["max_seq_lengths"][0])
+        else:
+            env_vars["TASK_METADATA"] = ""
+            env_vars["MAX_SEQ_LENGTH"] = ""
+        
         config = {}
         config["env_vars"] = env_vars
         config["slurm_config"] = slurm_config

--- a/evals/slurm.py
+++ b/evals/slurm.py
@@ -45,7 +45,7 @@ def read_command_log():
             for line in f.readlines():
                 entry = json.loads(line.rstrip())
                 entries[entry["job_id"]] = entry
-        return entries
+    return entries
 
 def get_jobs():
     command = ['squeue', '--me', '-o', '%i %T %j']

--- a/main.py
+++ b/main.py
@@ -154,7 +154,7 @@ def run_eval(eval_name, args):
         'LM_EVAL_REPO': lm_eval_config['LM_EVAL_REPO'],
         'LM_EVAL_REF': lm_eval_config['LM_EVAL_REF'],
         'LM_EVAL_PATH': lm_eval_config['LM_EVAL_PATH'],
-        'TRANSFORMERS_VERSION': args.transformers_version,
+        'TRANSFORMERS_VERSION': '4.57.1',  # Fixed version compatible with container's vLLM 0.12.0
     }
 
     job_name = f"vllm_{eval_name}" if backend == 'vllm' else eval_name
@@ -283,7 +283,6 @@ def main():
     parser.add_argument('--limit', type=int, help='Limit the number of examples per task (for testing purposes only)')
     parser.add_argument('--batch_size', type=str, default='', help='Batch size for inference (default: auto for vLLM, 4 for HF)')
     parser.add_argument('--lm_eval', type=str, help='lm-evaluation-harness source: URL, URL@ref, or local path (default: LumiOpen/main)')
-    parser.add_argument('--transformers_version', type=str, default='4.57.1', help='Transformers version to install in container (default: 4.57.1)')
     # slurm config
     parser.add_argument('--project', type=str, default="project_462000963", help="Project for sbatch job")
     parser.add_argument('--partition', type=str, default="small-g", help="Partition for sbatch job")

--- a/main.py
+++ b/main.py
@@ -286,7 +286,7 @@ def main():
     # slurm config
     parser.add_argument('--project', type=str, default="project_462000963", help="Project for sbatch job")
     parser.add_argument('--partition', type=str, default="small-g", help="Partition for sbatch job")
-    parser.add_argument('--gres', type=str, default="gpu:mi250:4", help="gres required for sbatch job")
+    parser.add_argument('--gres', type=str, default="gpu:mi250:8", help="gres required for sbatch job")
     parser.add_argument('--time', type=str, default="48:00:00", help="Time limit for sbatch job")
     parser.add_argument('--log_dir', type=str, default="./logs", help="Dir for slurm logs")
     parser.add_argument('--dependency', type=str, default=None, help="SLURM job dependency (e.g., afterok:12345)")

--- a/ruler-vllm.sh
+++ b/ruler-vllm.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Script to run RULER long context evaluations using vLLM backend
+# Usage: sh ruler-vllm.sh /path/to/model [--partition PARTITION] [--time TIME] [--gres GRES]
+
+if [ -z "$1" ]; then
+    echo "Usage: sh ruler-vllm.sh /path/to/model [--partition PARTITION] [--time TIME] [--gres GRES]"
+    echo ""
+    echo "Example:"
+    echo "  sh ruler-vllm.sh org/modelname"
+    echo "  sh ruler-vllm.sh /path/to/model --partition standard-g --time 24:00:00"
+    echo ""
+    echo "This script will run RULER evaluations using vLLM backend for the following sequence lengths:"
+    echo "  - 4096 tokens"
+    echo "  - 8192 tokens"
+    echo "  - 16384 tokens"
+    echo "  - 32768 tokens"
+    echo "  - 65536 tokens"
+    echo "  - 131072 tokens (128K)"
+    echo ""
+    echo "Note: vLLM backend is faster but experimental."
+    exit 1
+fi
+
+MODEL=$1
+shift
+
+# Default SLURM configuration
+# vLLM can be more efficient with memory, so we can use smaller resources
+PARTITION="standard-g"
+TIME="48:00:00"
+GRES="gpu:mi250:4"
+EXTRA_ARGS=""
+
+# Parse additional arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --partition)
+            PARTITION="$2"
+            shift 2
+            ;;
+        --time)
+            TIME="$2"
+            shift 2
+            ;;
+        --gres)
+            GRES="$2"
+            shift 2
+            ;;
+        *)
+            EXTRA_ARGS="$EXTRA_ARGS $1"
+            shift
+            ;;
+    esac
+done
+
+echo "=================================================="
+echo "Running RULER Long Context Evaluations (vLLM)"
+echo "=================================================="
+echo "Model: $MODEL"
+echo "Partition: $PARTITION"
+echo "Time: $TIME"
+echo "GRES: $GRES"
+echo "Backend: vllm"
+echo "Extra args: $EXTRA_ARGS"
+echo "=================================================="
+echo ""
+
+# RULER evaluations for each sequence length
+# Note: vLLM requires max_model_len to be set appropriately for each sequence length
+RULER_TASKS=(
+    "ruler_4096"
+    "ruler_8192"
+    "ruler_16384"
+    "ruler_32768"
+    "ruler_65536"
+    "ruler_131072"
+)
+
+# Corresponding max_model_len values (add some buffer for the context)
+MAX_MODEL_LENS=(
+    "8192"
+    "16384"
+    "32768"
+    "65536"
+    "131072"
+    "131072"
+)
+
+for i in "${!RULER_TASKS[@]}"; do
+    task="${RULER_TASKS[$i]}"
+    max_len="${MAX_MODEL_LENS[$i]}"
+    
+    echo "Submitting job for $task (max_model_len=$max_len)..."
+    python main.py \
+        --partition "$PARTITION" \
+        --time "$TIME" \
+        --gres "$GRES" \
+        --backend vllm \
+        --model "$MODEL" \
+        --model_args "max_model_len=$max_len,gpu_memory_utilization=0.95" \
+        $EXTRA_ARGS \
+        "$task"
+    echo ""
+done
+
+echo "=================================================="
+echo "All RULER evaluation jobs submitted!"
+echo "=================================================="
+echo ""
+echo "Monitor job status with:"
+echo "  python watch.py"
+echo ""
+echo "View results when complete with:"
+echo "  sh summary.sh output/v2/<model-name>"
+

--- a/ruler-vllm.sh
+++ b/ruler-vllm.sh
@@ -170,6 +170,7 @@ for subtask in "${SUBTASK_ARRAY[@]}"; do
             ${APPLY_CHAT_TEMPLATE:+--apply_chat_template} \
             ${FEWSHOT_AS_MULTITURN:+--fewshot_as_multiturn} \
             $EXTRA_ARGS \
+            -- \
             "$TASK_NAME"
         
         # Brief pause to avoid overwhelming the scheduler

--- a/ruler-vllm.sh
+++ b/ruler-vllm.sh
@@ -1,37 +1,63 @@
 #!/bin/bash
 # Script to run RULER long context evaluations using vLLM backend
-# Usage: sh ruler-vllm.sh /path/to/model [--partition PARTITION] [--time TIME] [--gres GRES]
+# Each subtask × sequence length combination runs as a separate SLURM job
+#
+# Usage: sh ruler-vllm.sh /path/to/model [OPTIONS]
 
 if [ -z "$1" ]; then
-    echo "Usage: sh ruler-vllm.sh /path/to/model [--partition PARTITION] [--time TIME] [--gres GRES]"
-    echo ""
-    echo "Example:"
-    echo "  sh ruler-vllm.sh org/modelname"
-    echo "  sh ruler-vllm.sh /path/to/model --partition standard-g --time 24:00:00"
-    echo ""
-    echo "This script will run RULER evaluations using vLLM backend for the following sequence lengths:"
-    echo "  - 4096 tokens"
-    echo "  - 8192 tokens"
-    echo "  - 16384 tokens"
-    echo "  - 32768 tokens"
-    echo "  - 65536 tokens"
-    echo "  - 131072 tokens (128K)"
-    echo ""
-    echo "Note: vLLM backend is faster but experimental."
+    cat <<EOF
+Usage: sh ruler-vllm.sh /path/to/model [OPTIONS]
+
+Examples:
+  # Run all RULER subtasks at all sequence lengths (78 jobs)
+  sh ruler-vllm.sh org/modelname
+
+  # Run specific subtasks at all sequence lengths
+  sh ruler-vllm.sh /path/to/model --subtasks "niah_single_1,vt,qa_1"
+
+  # Run all subtasks at specific sequence lengths
+  sh ruler-vllm.sh /path/to/model --sequence-lengths "4096,8192,16384"
+
+  # Run specific combinations
+  sh ruler-vllm.sh /path/to/model --subtasks "niah_single_1,vt" --sequence-lengths "4096,8192"
+
+  # Custom SLURM configuration
+  sh ruler-vllm.sh /path/to/model --partition standard-g --time 24:00:00 --gres gpu:mi250:8
+
+Available RULER subtasks (13 total):
+  Needle in a Haystack (NIAH):
+    niah_single_1, niah_single_2, niah_single_3
+    niah_multikey_1, niah_multikey_2, niah_multikey_3
+    niah_multivalue, niah_multiquery
+  Other tasks:
+    vt (Variable Tracking)
+    cwe (Common Words Extraction)
+    fwe (Frequent Words Extraction)
+    qa_1, qa_2 (Question Answering)
+
+Available sequence lengths:
+  4096, 8192, 16384, 32768, 65536, 131072
+
+Note: vLLM backend is faster but experimental.
+      Each subtask × sequence length combination runs as a separate SLURM job.
+EOF
     exit 1
 fi
 
 MODEL=$1
 shift
 
-# Default SLURM configuration
-# vLLM can be more efficient with memory, so we can use smaller resources
+# Default configuration
 PARTITION="standard-g"
 TIME="48:00:00"
 GRES="gpu:mi250:4"
 EXTRA_ARGS=""
 
-# Parse additional arguments
+# Default: all subtasks and all sequence lengths
+SUBTASKS="niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery,vt,cwe,fwe,qa_1,qa_2"
+SEQUENCE_LENGTHS="4096,8192,16384,32768,65536,131072"
+
+# Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --partition)
@@ -46,12 +72,36 @@ while [[ $# -gt 0 ]]; do
             GRES="$2"
             shift 2
             ;;
+        --subtasks)
+            SUBTASKS="$2"
+            shift 2
+            ;;
+        --sequence-lengths)
+            SEQUENCE_LENGTHS="$2"
+            shift 2
+            ;;
         *)
             EXTRA_ARGS="$EXTRA_ARGS $1"
             shift
             ;;
     esac
 done
+
+# Convert comma-separated strings to arrays
+IFS=',' read -ra SUBTASK_ARRAY <<< "$SUBTASKS"
+IFS=',' read -ra SEQLEN_ARRAY <<< "$SEQUENCE_LENGTHS"
+
+# Count total jobs
+TOTAL_JOBS=$((${#SUBTASK_ARRAY[@]} * ${#SEQLEN_ARRAY[@]}))
+
+# Map sequence lengths to max_model_len (with buffer)
+declare -A MAX_MODEL_LEN_MAP
+MAX_MODEL_LEN_MAP[4096]=8192
+MAX_MODEL_LEN_MAP[8192]=16384
+MAX_MODEL_LEN_MAP[16384]=32768
+MAX_MODEL_LEN_MAP[32768]=65536
+MAX_MODEL_LEN_MAP[65536]=131072
+MAX_MODEL_LEN_MAP[131072]=131072
 
 echo "=================================================="
 echo "Running RULER Long Context Evaluations (vLLM)"
@@ -62,54 +112,60 @@ echo "Time: $TIME"
 echo "GRES: $GRES"
 echo "Backend: vllm"
 echo "Extra args: $EXTRA_ARGS"
+echo ""
+echo "Subtasks: ${#SUBTASK_ARRAY[@]} (${SUBTASKS})"
+echo "Sequence lengths: ${#SEQLEN_ARRAY[@]} (${SEQUENCE_LENGTHS})"
+echo "Total SLURM jobs to submit: $TOTAL_JOBS"
 echo "=================================================="
 echo ""
 
-# RULER evaluations for each sequence length
-# Note: vLLM requires max_model_len to be set appropriately for each sequence length
-RULER_TASKS=(
-    "ruler_4096"
-    "ruler_8192"
-    "ruler_16384"
-    "ruler_32768"
-    "ruler_65536"
-    "ruler_131072"
-)
+# Confirm if submitting many jobs
+if [ $TOTAL_JOBS -gt 20 ]; then
+    echo "WARNING: You are about to submit $TOTAL_JOBS SLURM jobs."
+    echo "Press Ctrl+C to cancel, or Enter to continue..."
+    read -r
+fi
 
-# Corresponding max_model_len values (add some buffer for the context)
-MAX_MODEL_LENS=(
-    "8192"
-    "16384"
-    "32768"
-    "65536"
-    "131072"
-    "131072"
-)
+JOB_COUNT=0
 
-for i in "${!RULER_TASKS[@]}"; do
-    task="${RULER_TASKS[$i]}"
-    max_len="${MAX_MODEL_LENS[$i]}"
-    
-    echo "Submitting job for $task (max_model_len=$max_len)..."
-    python main.py \
-        --partition "$PARTITION" \
-        --time "$TIME" \
-        --gres "$GRES" \
-        --backend vllm \
-        --model "$MODEL" \
-        --model_args "max_model_len=$max_len,gpu_memory_utilization=0.95" \
-        $EXTRA_ARGS \
-        "$task"
-    echo ""
+# Submit jobs for each combination
+for subtask in "${SUBTASK_ARRAY[@]}"; do
+    for seqlen in "${SEQLEN_ARRAY[@]}"; do
+        JOB_COUNT=$((JOB_COUNT + 1))
+        TASK_NAME="ruler_${subtask}_${seqlen}"
+        MAX_LEN="${MAX_MODEL_LEN_MAP[$seqlen]}"
+        
+        echo "[$JOB_COUNT/$TOTAL_JOBS] Submitting SLURM job for $TASK_NAME (max_model_len=$MAX_LEN)..."
+        
+        # This calls main.py which internally generates and submits a SLURM job via sbatch
+        python main.py \
+            --partition "$PARTITION" \
+            --time "$TIME" \
+            --gres "$GRES" \
+            --backend vllm \
+            --model "$MODEL" \
+            --model_args "max_model_len=$MAX_LEN,gpu_memory_utilization=0.95" \
+            $EXTRA_ARGS \
+            "$TASK_NAME"
+        
+        # Brief pause to avoid overwhelming the scheduler
+        sleep 0.5
+    done
 done
 
+echo ""
 echo "=================================================="
-echo "All RULER evaluation jobs submitted!"
+echo "All $TOTAL_JOBS RULER evaluation jobs submitted!"
 echo "=================================================="
+echo ""
+echo "Each job runs independently in SLURM."
 echo ""
 echo "Monitor job status with:"
 echo "  python watch.py"
 echo ""
 echo "View results when complete with:"
 echo "  sh summary.sh output/v2/<model-name>"
-
+echo ""
+echo "Check specific task results:"
+echo "  ls output/v2/<model-name>/ruler_*"
+echo ""

--- a/ruler-vllm.sh
+++ b/ruler-vllm.sh
@@ -138,7 +138,7 @@ for subtask in "${SUBTASK_ARRAY[@]}"; do
         echo "[$JOB_COUNT/$TOTAL_JOBS] Submitting SLURM job for $TASK_NAME (max_model_len=$MAX_LEN)..."
         
         # This calls main.py which internally generates and submits a SLURM job via sbatch
-        python main.py \
+        python3 main.py \
             --partition "$PARTITION" \
             --time "$TIME" \
             --gres "$GRES" \

--- a/ruler-vllm.sh
+++ b/ruler-vllm.sh
@@ -13,13 +13,13 @@ Examples:
   sh ruler-vllm.sh org/modelname
 
   # Run specific subtasks at all sequence lengths
-  sh ruler-vllm.sh /path/to/model --subtasks "niah_single_1,vt,qa_1"
+  sh ruler-vllm.sh /path/to/model --subtasks "niah_single_1,ruler_vt,ruler_qa_hotpot"
 
   # Run all subtasks at specific sequence lengths
   sh ruler-vllm.sh /path/to/model --sequence-lengths "4096,8192,16384"
 
   # Run specific combinations
-  sh ruler-vllm.sh /path/to/model --subtasks "niah_single_1,vt" --sequence-lengths "4096,8192"
+  sh ruler-vllm.sh /path/to/model --subtasks "niah_single_1,ruler_vt" --sequence-lengths "4096,8192"
 
   # Custom SLURM configuration
   sh ruler-vllm.sh /path/to/model --partition standard-g --time 24:00:00 --gres gpu:mi250:8
@@ -30,10 +30,11 @@ Available RULER subtasks (13 total):
     niah_multikey_1, niah_multikey_2, niah_multikey_3
     niah_multivalue, niah_multiquery
   Other tasks:
-    vt (Variable Tracking)
-    cwe (Common Words Extraction)
-    fwe (Frequent Words Extraction)
-    qa_1, qa_2 (Question Answering)
+    ruler_vt (Variable Tracking)
+    ruler_cwe (Common Words Extraction)
+    ruler_fwe (Frequent Words Extraction)
+    ruler_qa_hotpot (QA - Hotpot)
+    ruler_qa_squad (QA - SQuADv2)
 
 Available sequence lengths:
   4096, 8192, 16384, 32768, 65536, 131072
@@ -54,7 +55,8 @@ GRES="gpu:mi250:4"
 EXTRA_ARGS=""
 
 # Default: all subtasks and all sequence lengths
-SUBTASKS="niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery,vt,cwe,fwe,qa_1,qa_2"
+# From: https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/ruler#tasks
+SUBTASKS="niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery,ruler_vt,ruler_cwe,ruler_fwe,ruler_qa_hotpot,ruler_qa_squad"
 SEQUENCE_LENGTHS="4096,8192,16384,32768,65536,131072"
 
 # Parse arguments

--- a/ruler-vllm.sh
+++ b/ruler-vllm.sh
@@ -24,6 +24,12 @@ Examples:
   # Custom SLURM configuration
   sh ruler-vllm.sh /path/to/model --partition standard-g --time 24:00:00 --gres gpu:mi250:8
 
+  # SFT/instruct model with chat template
+  sh ruler-vllm.sh /path/to/sft-model --apply_chat_template --fewshot_as_multiturn
+
+  # SFT model via environment variables (same as cpt-vllm.sh pattern)
+  APPLY_CHAT_TEMPLATE=True FEWSHOT_AS_MULTITURN=True sh ruler-vllm.sh /path/to/sft-model
+
 Available RULER subtasks (13 total):
   Needle in a Haystack (NIAH):
     niah_single_1, niah_single_2, niah_single_3
@@ -54,6 +60,10 @@ TIME="48:00:00"
 GRES="gpu:mi250:4"
 EXTRA_ARGS=""
 
+# Chat template flags (also read from env vars, same pattern as cpt-vllm.sh)
+APPLY_CHAT_TEMPLATE="${APPLY_CHAT_TEMPLATE:-}"
+FEWSHOT_AS_MULTITURN="${FEWSHOT_AS_MULTITURN:-}"
+
 # Default: all subtasks and all sequence lengths
 # From: https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/ruler#tasks
 SUBTASKS="niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery,ruler_vt,ruler_cwe,ruler_fwe,ruler_qa_hotpot,ruler_qa_squad"
@@ -81,6 +91,14 @@ while [[ $# -gt 0 ]]; do
         --sequence-lengths)
             SEQUENCE_LENGTHS="$2"
             shift 2
+            ;;
+        --apply_chat_template|--apply-chat-template)
+            APPLY_CHAT_TEMPLATE="True"
+            shift
+            ;;
+        --fewshot_as_multiturn|--fewshot-as-multiturn)
+            FEWSHOT_AS_MULTITURN="True"
+            shift
             ;;
         *)
             EXTRA_ARGS="$EXTRA_ARGS $1"
@@ -113,6 +131,8 @@ echo "Partition: $PARTITION"
 echo "Time: $TIME"
 echo "GRES: $GRES"
 echo "Backend: vllm"
+echo "Apply chat template: ${APPLY_CHAT_TEMPLATE:-no}"
+echo "Fewshot as multiturn: ${FEWSHOT_AS_MULTITURN:-no}"
 echo "Extra args: $EXTRA_ARGS"
 echo ""
 echo "Subtasks: ${#SUBTASK_ARRAY[@]} (${SUBTASKS})"
@@ -147,6 +167,8 @@ for subtask in "${SUBTASK_ARRAY[@]}"; do
             --backend vllm \
             --model "$MODEL" \
             --model_args "max_model_len=$MAX_LEN,gpu_memory_utilization=0.95" \
+            ${APPLY_CHAT_TEMPLATE:+--apply_chat_template} \
+            ${FEWSHOT_AS_MULTITURN:+--fewshot_as_multiturn} \
             $EXTRA_ARGS \
             "$TASK_NAME"
         

--- a/ruler.sh
+++ b/ruler.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Script to run RULER long context evaluations across multiple sequence lengths
+# Usage: sh ruler.sh /path/to/model [--partition PARTITION] [--time TIME] [--gres GRES]
+
+if [ -z "$1" ]; then
+    echo "Usage: sh ruler.sh /path/to/model [--partition PARTITION] [--time TIME] [--gres GRES]"
+    echo ""
+    echo "Example:"
+    echo "  sh ruler.sh /path/to/model"
+    echo "  sh ruler.sh /path/to/model --partition standard-g --time 24:00:00"
+    echo ""
+    echo "This script will run RULER evaluations for the following sequence lengths:"
+    echo "  - 4096 tokens"
+    echo "  - 8192 tokens"
+    echo "  - 16384 tokens"
+    echo "  - 32768 tokens"
+    echo "  - 65536 tokens"
+    echo "  - 131072 tokens (128K)"
+    exit 1
+fi
+
+MODEL=$1
+shift
+
+# Default SLURM configuration
+PARTITION="standard-g"
+TIME="48:00:00"
+GRES="gpu:mi250:4"
+BACKEND="hf"
+EXTRA_ARGS=""
+
+# Parse additional arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --partition)
+            PARTITION="$2"
+            shift 2
+            ;;
+        --time)
+            TIME="$2"
+            shift 2
+            ;;
+        --gres)
+            GRES="$2"
+            shift 2
+            ;;
+        --backend)
+            BACKEND="$2"
+            shift 2
+            ;;
+        *)
+            EXTRA_ARGS="$EXTRA_ARGS $1"
+            shift
+            ;;
+    esac
+done
+
+echo "=================================================="
+echo "Running RULER Long Context Evaluations"
+echo "=================================================="
+echo "Model: $MODEL"
+echo "Partition: $PARTITION"
+echo "Time: $TIME"
+echo "GRES: $GRES"
+echo "Backend: $BACKEND"
+echo "Extra args: $EXTRA_ARGS"
+echo "=================================================="
+echo ""
+
+# RULER evaluations for each sequence length
+# Note: Longer context lengths require more time and memory
+RULER_TASKS=(
+    "ruler_4096"
+    "ruler_8192"
+    "ruler_16384"
+    "ruler_32768"
+    "ruler_65536"
+    "ruler_131072"
+)
+
+for task in "${RULER_TASKS[@]}"; do
+    echo "Submitting job for $task..."
+    python main.py \
+        --partition "$PARTITION" \
+        --time "$TIME" \
+        --gres "$GRES" \
+        --backend "$BACKEND" \
+        --model "$MODEL" \
+        $EXTRA_ARGS \
+        "$task"
+    echo ""
+done
+
+echo "=================================================="
+echo "All RULER evaluation jobs submitted!"
+echo "=================================================="
+echo ""
+echo "Monitor job status with:"
+echo "  python watch.py"
+echo ""
+echo "View results when complete with:"
+echo "  sh summary.sh output/v2/<model-name>"
+

--- a/ruler.sh
+++ b/ruler.sh
@@ -135,7 +135,7 @@ for subtask in "${SUBTASK_ARRAY[@]}"; do
         echo "[$JOB_COUNT/$TOTAL_JOBS] Submitting SLURM job for $TASK_NAME..."
         
         # This calls main.py which internally generates and submits a SLURM job via sbatch
-        python main.py \
+        python3 main.py \
             --partition "$PARTITION" \
             --time "$TIME" \
             --gres "$GRES" \

--- a/ruler.sh
+++ b/ruler.sh
@@ -13,13 +13,13 @@ Examples:
   sh ruler.sh /path/to/model
 
   # Run specific subtasks at all sequence lengths
-  sh ruler.sh /path/to/model --subtasks "niah_single_1,vt,qa_1"
+  sh ruler.sh /path/to/model --subtasks "niah_single_1,ruler_vt,ruler_qa_hotpot"
 
   # Run all subtasks at specific sequence lengths
   sh ruler.sh /path/to/model --sequence-lengths "4096,8192,16384"
 
   # Run specific combinations
-  sh ruler.sh /path/to/model --subtasks "niah_single_1,vt" --sequence-lengths "4096,8192"
+  sh ruler.sh /path/to/model --subtasks "niah_single_1,ruler_vt" --sequence-lengths "4096,8192"
 
   # Custom SLURM configuration
   sh ruler.sh /path/to/model --partition standard-g --time 24:00:00 --gres gpu:mi250:8
@@ -30,10 +30,11 @@ Available RULER subtasks (13 total):
     niah_multikey_1, niah_multikey_2, niah_multikey_3
     niah_multivalue, niah_multiquery
   Other tasks:
-    vt (Variable Tracking)
-    cwe (Common Words Extraction)
-    fwe (Frequent Words Extraction)
-    qa_1, qa_2 (Question Answering)
+    ruler_vt (Variable Tracking)
+    ruler_cwe (Common Words Extraction)
+    ruler_fwe (Frequent Words Extraction)
+    ruler_qa_hotpot (QA - Hotpot)
+    ruler_qa_squad (QA - SQuADv2)
 
 Available sequence lengths:
   4096, 8192, 16384, 32768, 65536, 131072
@@ -55,7 +56,8 @@ BACKEND="hf"
 EXTRA_ARGS=""
 
 # Default: all subtasks and all sequence lengths
-SUBTASKS="niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery,vt,cwe,fwe,qa_1,qa_2"
+# From: https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/ruler#tasks
+SUBTASKS="niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery,ruler_vt,ruler_cwe,ruler_fwe,ruler_qa_hotpot,ruler_qa_squad"
 SEQUENCE_LENGTHS="4096,8192,16384,32768,65536,131072"
 
 # Parse arguments

--- a/ruler.sh
+++ b/ruler.sh
@@ -1,35 +1,64 @@
 #!/bin/bash
-# Script to run RULER long context evaluations across multiple sequence lengths
-# Usage: sh ruler.sh /path/to/model [--partition PARTITION] [--time TIME] [--gres GRES]
+# Script to run RULER long context evaluations across multiple subtasks and sequence lengths
+# Each subtask × sequence length combination runs as a separate SLURM job
+#
+# Usage: sh ruler.sh /path/to/model [OPTIONS]
 
 if [ -z "$1" ]; then
-    echo "Usage: sh ruler.sh /path/to/model [--partition PARTITION] [--time TIME] [--gres GRES]"
-    echo ""
-    echo "Example:"
-    echo "  sh ruler.sh /path/to/model"
-    echo "  sh ruler.sh /path/to/model --partition standard-g --time 24:00:00"
-    echo ""
-    echo "This script will run RULER evaluations for the following sequence lengths:"
-    echo "  - 4096 tokens"
-    echo "  - 8192 tokens"
-    echo "  - 16384 tokens"
-    echo "  - 32768 tokens"
-    echo "  - 65536 tokens"
-    echo "  - 131072 tokens (128K)"
+    cat <<EOF
+Usage: sh ruler.sh /path/to/model [OPTIONS]
+
+Examples:
+  # Run all RULER subtasks at all sequence lengths (78 jobs)
+  sh ruler.sh /path/to/model
+
+  # Run specific subtasks at all sequence lengths
+  sh ruler.sh /path/to/model --subtasks "niah_single_1,vt,qa_1"
+
+  # Run all subtasks at specific sequence lengths
+  sh ruler.sh /path/to/model --sequence-lengths "4096,8192,16384"
+
+  # Run specific combinations
+  sh ruler.sh /path/to/model --subtasks "niah_single_1,vt" --sequence-lengths "4096,8192"
+
+  # Custom SLURM configuration
+  sh ruler.sh /path/to/model --partition standard-g --time 24:00:00 --gres gpu:mi250:8
+
+Available RULER subtasks (13 total):
+  Needle in a Haystack (NIAH):
+    niah_single_1, niah_single_2, niah_single_3
+    niah_multikey_1, niah_multikey_2, niah_multikey_3
+    niah_multivalue, niah_multiquery
+  Other tasks:
+    vt (Variable Tracking)
+    cwe (Common Words Extraction)
+    fwe (Frequent Words Extraction)
+    qa_1, qa_2 (Question Answering)
+
+Available sequence lengths:
+  4096, 8192, 16384, 32768, 65536, 131072
+
+Note: Each subtask × sequence length combination runs as a separate SLURM job.
+      This allows parallel execution and fine-grained resource management.
+EOF
     exit 1
 fi
 
 MODEL=$1
 shift
 
-# Default SLURM configuration
+# Default configuration
 PARTITION="standard-g"
 TIME="48:00:00"
 GRES="gpu:mi250:4"
 BACKEND="hf"
 EXTRA_ARGS=""
 
-# Parse additional arguments
+# Default: all subtasks and all sequence lengths
+SUBTASKS="niah_single_1,niah_single_2,niah_single_3,niah_multikey_1,niah_multikey_2,niah_multikey_3,niah_multivalue,niah_multiquery,vt,cwe,fwe,qa_1,qa_2"
+SEQUENCE_LENGTHS="4096,8192,16384,32768,65536,131072"
+
+# Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --partition)
@@ -48,12 +77,27 @@ while [[ $# -gt 0 ]]; do
             BACKEND="$2"
             shift 2
             ;;
+        --subtasks)
+            SUBTASKS="$2"
+            shift 2
+            ;;
+        --sequence-lengths)
+            SEQUENCE_LENGTHS="$2"
+            shift 2
+            ;;
         *)
             EXTRA_ARGS="$EXTRA_ARGS $1"
             shift
             ;;
     esac
 done
+
+# Convert comma-separated strings to arrays
+IFS=',' read -ra SUBTASK_ARRAY <<< "$SUBTASKS"
+IFS=',' read -ra SEQLEN_ARRAY <<< "$SEQUENCE_LENGTHS"
+
+# Count total jobs
+TOTAL_JOBS=$((${#SUBTASK_ARRAY[@]} * ${#SEQLEN_ARRAY[@]}))
 
 echo "=================================================="
 echo "Running RULER Long Context Evaluations"
@@ -64,40 +108,58 @@ echo "Time: $TIME"
 echo "GRES: $GRES"
 echo "Backend: $BACKEND"
 echo "Extra args: $EXTRA_ARGS"
+echo ""
+echo "Subtasks: ${#SUBTASK_ARRAY[@]} (${SUBTASKS})"
+echo "Sequence lengths: ${#SEQLEN_ARRAY[@]} (${SEQUENCE_LENGTHS})"
+echo "Total SLURM jobs to submit: $TOTAL_JOBS"
 echo "=================================================="
 echo ""
 
-# RULER evaluations for each sequence length
-# Note: Longer context lengths require more time and memory
-RULER_TASKS=(
-    "ruler_4096"
-    "ruler_8192"
-    "ruler_16384"
-    "ruler_32768"
-    "ruler_65536"
-    "ruler_131072"
-)
+# Confirm if submitting many jobs
+if [ $TOTAL_JOBS -gt 20 ]; then
+    echo "WARNING: You are about to submit $TOTAL_JOBS SLURM jobs."
+    echo "Press Ctrl+C to cancel, or Enter to continue..."
+    read -r
+fi
 
-for task in "${RULER_TASKS[@]}"; do
-    echo "Submitting job for $task..."
-    python main.py \
-        --partition "$PARTITION" \
-        --time "$TIME" \
-        --gres "$GRES" \
-        --backend "$BACKEND" \
-        --model "$MODEL" \
-        $EXTRA_ARGS \
-        "$task"
-    echo ""
+JOB_COUNT=0
+
+# Submit jobs for each combination
+for subtask in "${SUBTASK_ARRAY[@]}"; do
+    for seqlen in "${SEQLEN_ARRAY[@]}"; do
+        JOB_COUNT=$((JOB_COUNT + 1))
+        TASK_NAME="ruler_${subtask}_${seqlen}"
+        
+        echo "[$JOB_COUNT/$TOTAL_JOBS] Submitting SLURM job for $TASK_NAME..."
+        
+        # This calls main.py which internally generates and submits a SLURM job via sbatch
+        python main.py \
+            --partition "$PARTITION" \
+            --time "$TIME" \
+            --gres "$GRES" \
+            --backend "$BACKEND" \
+            --model "$MODEL" \
+            $EXTRA_ARGS \
+            "$TASK_NAME"
+        
+        # Brief pause to avoid overwhelming the scheduler
+        sleep 0.5
+    done
 done
 
+echo ""
 echo "=================================================="
-echo "All RULER evaluation jobs submitted!"
+echo "All $TOTAL_JOBS RULER evaluation jobs submitted!"
 echo "=================================================="
+echo ""
+echo "Each job runs independently in SLURM."
 echo ""
 echo "Monitor job status with:"
 echo "  python watch.py"
 echo ""
 echo "View results when complete with:"
 echo "  sh summary.sh output/v2/<model-name>"
-
+echo ""
+echo "Check specific task results:"
+echo "  ls output/v2/<model-name>/ruler_*"
+echo ""

--- a/summary.sh
+++ b/summary.sh
@@ -677,4 +677,41 @@ if [ -f $DIR/alpaca_eval_fi.json ] ; then
     cat $DIR/alpaca_eval_fi.json | jq '.results.length_controlled_winrate'
 fi
 
+# RULER long context evaluations
+if [ -f $DIR/ruler_4096.json ] || [ -f $DIR/ruler_8192.json ] || [ -f $DIR/ruler_16384.json ] || [ -f $DIR/ruler_32768.json ] || [ -f $DIR/ruler_65536.json ] || [ -f $DIR/ruler_131072.json ] ; then
+    echo
+    echo "RULER Long Context:"
+fi
+
+if [ -f $DIR/ruler_4096.json ] ; then
+    echo -n "     ruler_4096 (4K): "
+    # Try to get average of all ruler subtasks
+    cat $DIR/ruler_4096.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
+fi
+
+if [ -f $DIR/ruler_8192.json ] ; then
+    echo -n "     ruler_8192 (8K): "
+    cat $DIR/ruler_8192.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
+fi
+
+if [ -f $DIR/ruler_16384.json ] ; then
+    echo -n "    ruler_16384 (16K): "
+    cat $DIR/ruler_16384.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
+fi
+
+if [ -f $DIR/ruler_32768.json ] ; then
+    echo -n "    ruler_32768 (32K): "
+    cat $DIR/ruler_32768.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
+fi
+
+if [ -f $DIR/ruler_65536.json ] ; then
+    echo -n "    ruler_65536 (64K): "
+    cat $DIR/ruler_65536.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
+fi
+
+if [ -f $DIR/ruler_131072.json ] ; then
+    echo -n "   ruler_131072 (128K): "
+    cat $DIR/ruler_131072.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
+fi
+
 echo

--- a/summary.sh
+++ b/summary.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
 # script to summarize the most commonly-used results in a standard way.
+# Note: For RULER long context evaluations, use summary_ruler.sh instead.
 
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <DIR>"
+    echo ""
+    echo "Note: For RULER long context results, use summary_ruler.sh"
     exit 1
 fi
 DIR=$1
@@ -711,43 +714,6 @@ fi
 if [ -f $DIR/alpaca_eval_fi.json ] ; then
     echo -n "     alpaca_eval_fi length_controlled_winrate: "
     cat $DIR/alpaca_eval_fi.json | jq '.results.length_controlled_winrate'
-fi
-
-# RULER long context evaluations
-if [ -f $DIR/ruler_4096.json ] || [ -f $DIR/ruler_8192.json ] || [ -f $DIR/ruler_16384.json ] || [ -f $DIR/ruler_32768.json ] || [ -f $DIR/ruler_65536.json ] || [ -f $DIR/ruler_131072.json ] ; then
-    echo
-    echo "RULER Long Context:"
-fi
-
-if [ -f $DIR/ruler_4096.json ] ; then
-    echo -n "     ruler_4096 (4K): "
-    # Try to get average of all ruler subtasks
-    cat $DIR/ruler_4096.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
-fi
-
-if [ -f $DIR/ruler_8192.json ] ; then
-    echo -n "     ruler_8192 (8K): "
-    cat $DIR/ruler_8192.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
-fi
-
-if [ -f $DIR/ruler_16384.json ] ; then
-    echo -n "    ruler_16384 (16K): "
-    cat $DIR/ruler_16384.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
-fi
-
-if [ -f $DIR/ruler_32768.json ] ; then
-    echo -n "    ruler_32768 (32K): "
-    cat $DIR/ruler_32768.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
-fi
-
-if [ -f $DIR/ruler_65536.json ] ; then
-    echo -n "    ruler_65536 (64K): "
-    cat $DIR/ruler_65536.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
-fi
-
-if [ -f $DIR/ruler_131072.json ] ; then
-    echo -n "   ruler_131072 (128K): "
-    cat $DIR/ruler_131072.json | jq '[.results | to_entries[] | select(.key | startswith("ruler_")) | .value | to_entries[] | select(.key | endswith(",none") or .key == "acc" or .key == "exact_match") | .value] | add / length' | awk '{print $1 * 100}'
 fi
 
 echo

--- a/summary.sh
+++ b/summary.sh
@@ -11,6 +11,8 @@ DIR=$1
 echo -n "    arc_challenge: "
 if [ -f $DIR/arc_challenge.json ] ; then 
     cat $DIR/arc_challenge.json | jq '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_arc_challenge.json ] ; then 
+    cat $DIR/vllm_arc_challenge.json | jq '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -22,6 +24,8 @@ fi
 echo -n "        hellaswag: "
 if [ -f $DIR/hellaswag.json ] ; then
     cat $DIR/hellaswag.json | jq '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_hellaswag.json ] ; then
+    cat $DIR/vllm_hellaswag.json | jq '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -33,6 +37,8 @@ fi
 echo -n "       goldenswag: "
 if [ -f $DIR/goldenswag.json ] ; then
     cat $DIR/goldenswag.json | jq '.results.goldenswag.acc_norm // .results.goldenswag["acc_norm,none"]' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_goldenswag.json ] ; then
+    cat $DIR/vllm_goldenswag.json | jq '.results.goldenswag.acc_norm // .results.goldenswag["acc_norm,none"]' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -40,6 +46,8 @@ fi
 echo -n "             mmlu: "
 if [ -f $DIR/mmlu.json ] ; then
     cat $DIR/mmlu.json | jq '[if .results.mmlu | has("acc,none") then .results.mmlu["acc,none"] else .results | .[] | .acc end] | add / length * 100'
+elif [ -f $DIR/vllm_mmlu.json ] ; then
+    cat $DIR/vllm_mmlu.json | jq '[if .results.mmlu | has("acc,none") then .results.mmlu["acc,none"] else .results | .[] | .acc end] | add / length * 100'
 else
     echo na
 fi
@@ -51,6 +59,8 @@ fi
 echo -n "    truthfulqa_mc: "
 if [ -f $DIR/truthfulqa_mc.json ] ; then 
     cat $DIR/truthfulqa_mc.json | jq '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc2["acc,none"]' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_truthfulqa_mc.json ] ; then 
+    cat $DIR/vllm_truthfulqa_mc.json | jq '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc2["acc,none"]' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -62,6 +72,8 @@ fi
 echo -n "       winogrande: "
 if [ -f $DIR/winogrande.json ] ; then
    cat $DIR/winogrande.json | jq '.results.winogrande.acc // .results.winogrande["acc,none"]' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_winogrande.json ] ; then
+   cat $DIR/vllm_winogrande.json | jq '.results.winogrande.acc // .results.winogrande["acc,none"]' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -73,6 +85,8 @@ fi
 echo -n "            gsm8k: "
 if [ -f $DIR/gsm8k.json ] ; then
     cat $DIR/gsm8k.json | jq '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_gsm8k.json ] ; then
+    cat $DIR/vllm_gsm8k.json | jq '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -146,6 +160,10 @@ if [ -f $DIR/arc_challenge_fi.json ] ; then
     cat $DIR/arc_challenge_fi.json | jq '.results.arc_challenge_fi.acc_norm' | awk '{print $1 * 100}'
 elif [ -f $DIR/arc_challenge_mt_fi.json ] ; then 
     cat $DIR/arc_challenge_mt_fi.json | jq '.results.arc_challenge_mt_fi["acc_norm,none"]' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_arc_challenge_fi.json ] ; then 
+    cat $DIR/vllm_arc_challenge_fi.json | jq '.results.arc_challenge_fi.acc_norm' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_arc_challenge_mt_fi.json ] ; then 
+    cat $DIR/vllm_arc_challenge_mt_fi.json | jq '.results.arc_challenge_mt_fi["acc_norm,none"]' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -153,12 +171,16 @@ fi
 echo -n "    hellaswag_mt_fi: "
 if [ -f $DIR/hellaswag_mt_fi.json ] ; then
     cat $DIR/hellaswag_mt_fi.json | jq '.results.ogx_hellaswagx_fi."acc,none"' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_hellaswag_mt_fi.json ] ; then
+    cat $DIR/vllm_hellaswag_mt_fi.json | jq '.results.ogx_hellaswagx_fi."acc,none"' | awk '{print $1 * 100}'
 else
     echo na
 fi
 echo -n "    goldenswag_mt_fi: "
 if [ -f $DIR/goldenswag_mt_fi.json ] ; then
     cat $DIR/goldenswag_mt_fi.json | jq '.results.ogx_goldenswagx_fi."acc,none"' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_goldenswag_mt_fi.json ] ; then
+    cat $DIR/vllm_goldenswag_mt_fi.json | jq '.results.ogx_goldenswagx_fi."acc,none"' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -166,6 +188,8 @@ fi
 echo -n "         mmlu_mt_fi: "
 if [ -f $DIR/mmlu_mt_fi.json ] ; then
     cat $DIR/mmlu_mt_fi.json | jq '.groups.ogx_mmlux_FI."acc,none"' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_mmlu_mt_fi.json ] ; then
+    cat $DIR/vllm_mmlu_mt_fi.json | jq '.groups.ogx_mmlux_FI."acc,none"' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -173,6 +197,8 @@ fi
 echo -n "truthfulqa_mc_mt_fi: "
 if [ -f $DIR/truthfulqa_mc_mt_fi.json ] ; then
     cat $DIR/truthfulqa_mc_mt_fi.json | jq '.results.ogx_truthfulqax_mc2_fi."acc,none"' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_truthfulqa_mc_mt_fi.json ] ; then
+    cat $DIR/vllm_truthfulqa_mc_mt_fi.json | jq '.results.ogx_truthfulqax_mc2_fi."acc,none"' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -180,6 +206,8 @@ fi
 echo -n "        gsm8k_mt_fi: "
 if [ -f $DIR/gsm8k_mt_fi.json ] ; then
     cat $DIR/gsm8k_mt_fi.json | jq '.results.ogx_gsm8kx_fi."acc,none"' | awk '{print $1 * 100}'
+elif [ -f $DIR/vllm_gsm8k_mt_fi.json ] ; then
+    cat $DIR/vllm_gsm8k_mt_fi.json | jq '.results.ogx_gsm8kx_fi."acc,none"' | awk '{print $1 * 100}'
 else
     echo na
 fi
@@ -189,6 +217,8 @@ echo
 echo -n "    flores200_en_fi bleu: "
 if [ -f $DIR/flores200_trans_en_fi.json ] ; then
     cat $DIR/flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
+elif [ -f $DIR/vllm_flores200_trans_en_fi.json ] ; then
+    cat $DIR/vllm_flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
 else
     echo na
 fi
@@ -196,6 +226,8 @@ fi
 echo -n "    flores200_fi_en bleu: "
 if [ -f $DIR/flores200_trans_fi_en.json ] ; then
     cat $DIR/flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
+elif [ -f $DIR/vllm_flores200_trans_fi_en.json ] ; then
+    cat $DIR/vllm_flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
 else
     echo na
 fi
@@ -203,6 +235,8 @@ fi
 echo -n "    flores200_en_fi chrf: "
 if [ -f $DIR/flores200_trans_en_fi.json ] ; then
     cat $DIR/flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
+elif [ -f $DIR/vllm_flores200_trans_en_fi.json ] ; then
+    cat $DIR/vllm_flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
 else
     echo na
 fi
@@ -210,6 +244,8 @@ fi
 echo -n "    flores200_fi_en chrf: "
 if [ -f $DIR/flores200_trans_fi_en.json ] ; then
     cat $DIR/flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
+elif [ -f $DIR/vllm_flores200_trans_fi_en.json ] ; then
+    cat $DIR/vllm_flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
 else
     echo na
 fi

--- a/summary.sh
+++ b/summary.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# filepath: \scratch\project_462000963\users\jouni\evals-ruler\new-lumi\evals\summary.sh
 
 # script to summarize the most commonly-used results in a standard way.
 # Note: For RULER long context evaluations, use summary_ruler.sh instead.
@@ -11,103 +12,195 @@ if [ "$#" -ne 1 ]; then
 fi
 DIR=$1
 
-echo -n "    arc_challenge: "
-if [ -f $DIR/arc_challenge.json ] ; then 
-    cat $DIR/arc_challenge.json | jq '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_arc_challenge.json ] ; then 
-    cat $DIR/vllm_arc_challenge.json | jq '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/arc_challenge2.json ] ; then 
-    echo -n "   arc_challenge2: "
-    cat $DIR/arc_challenge2.json | jq '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' | awk '{print $1 * 100}'
+pick_file() {
+    local stem="$1"
+
+    local exact="$DIR/${stem}.json"
+    local exact_vllm="$DIR/vllm_${stem}.json"
+
+    # Prefer legacy files when they exist and are non-empty.
+    if [ -s "$exact" ]; then
+        echo "$exact"
+        return
+    fi
+    if [ -s "$exact_vllm" ]; then
+        echo "$exact_vllm"
+        return
+    fi
+
+    # Otherwise accept timestamp-suffixed files and pick newest non-empty.
+    # Important: avoid accidentally matching *other* task stems that merely share a prefix.
+    # Example: for stem="arc_challenge", we want vllm_arc_challenge_<ts>.json
+    # but NOT vllm_arc_challenge_mt_fi_<ts>.json.
+    local candidates=()
+    local nonempty=()
+    local filtered=()
+
+    shopt -s nullglob
+    candidates=(
+        "$DIR/${stem}"_*.json
+        "$DIR/${stem}"-*.json
+        "$DIR/vllm_${stem}"_*.json
+        "$DIR/vllm_${stem}"-*.json
+    )
+    shopt -u nullglob
+
+    for f in "${candidates[@]}"; do
+        [ -s "$f" ] && nonempty+=("$f")
+    done
+
+    # Prefer files where the suffix right after "${stem}_" or "${stem}-" starts with a digit
+    # (our timestamped outputs begin with YYYY-...). This filters out e.g. "${stem}_mt_fi_...".
+    for f in "${nonempty[@]}"; do
+        local base base_no_prefix rest
+        base="$(basename -- "$f")"
+        base_no_prefix="$base"
+        base_no_prefix="${base_no_prefix#vllm_}"
+
+        if [[ "$base_no_prefix" == "${stem}_"* ]]; then
+            rest="${base_no_prefix#${stem}_}"
+            [[ "$rest" =~ ^[0-9] ]] && filtered+=("$f")
+        elif [[ "$base_no_prefix" == "${stem}-"* ]]; then
+            rest="${base_no_prefix#${stem}-}"
+            [[ "$rest" =~ ^[0-9] ]] && filtered+=("$f")
+        fi
+    done
+
+    if [ ${#filtered[@]} -gt 0 ]; then
+        nonempty=("${filtered[@]}")
+    fi
+
+    if [ ${#nonempty[@]} -gt 0 ]; then
+        ls -1t "${nonempty[@]}" 2>/dev/null | head -n 1
+        return
+    fi
+
+    echo ""
+}
+
+# Fallback: pick newest non-empty JSON in $DIR where jq_filter yields a value
+pick_file_by_jq() {
+    local jq_filter="$1"
+
+    local candidates=()
+    local nonempty=()
+    local matched=()
+
+    shopt -s nullglob
+    candidates=("$DIR"/*.json)
+    shopt -u nullglob
+
+    for f in "${candidates[@]}"; do
+        [ -s "$f" ] && nonempty+=("$f")
+    done
+
+    for f in "${nonempty[@]}"; do
+        local v
+        v="$(jq -r "$jq_filter" "$f" 2>/dev/null)"
+        if [ -n "$v" ] && [ "$v" != "null" ]; then
+            matched+=("$f")
+        fi
+    done
+
+    if [ ${#matched[@]} -gt 0 ]; then
+        ls -1t "${matched[@]}" 2>/dev/null | head -n 1
+        return
+    fi
+
+    echo ""
+}
+
+print_metric() {
+    # Args: label, stem, jq_filter, scale
+    local label="$1"
+    local stem="$2"
+    local jq_filter="$3"
+    local scale="${4:-1}"
+
+    echo -n "$label"
+    local file
+    file="$(pick_file "$stem")"
+
+local val
+if [ -n "$file" ]; then
+    val="$(jq -r "$jq_filter" "$file" 2>/dev/null)"
 fi
 
-echo -n "        hellaswag: "
-if [ -f $DIR/hellaswag.json ] ; then
-    cat $DIR/hellaswag.json | jq '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_hellaswag.json ] ; then
-    cat $DIR/vllm_hellaswag.json | jq '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/hellaswag2.json ] ; then
-    echo -n "       hellaswag2: "
-    cat $DIR/hellaswag2.json | jq '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' | awk '{print $1 * 100}'
-fi
-
-echo -n "       goldenswag: "
-if [ -f $DIR/goldenswag.json ] ; then
-    cat $DIR/goldenswag.json | jq '.results.goldenswag.acc_norm // .results.goldenswag["acc_norm,none"]' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_goldenswag.json ] ; then
-    cat $DIR/vllm_goldenswag.json | jq '.results.goldenswag.acc_norm // .results.goldenswag["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
+# If stem selection fails (missing file or metric not in that file),
+# fall back to scanning for a JSON where jq_filter yields a value.
+if [ -z "$file" ] || [ -z "$val" ] || [ "$val" = "null" ]; then
+    file="$(pick_file_by_jq "$jq_filter")"
+    if [ -z "$file" ]; then
+        echo "na"
+        return
+    fi
+    val="$(jq -r "$jq_filter" "$file" 2>/dev/null)"
+    if [ -z "$val" ] || [ "$val" = "null" ]; then
+        echo "na"
+        return
+    fi
 fi
 
+    awk -v v="$val" -v s="$scale" 'BEGIN { print v * s }'
+}
+
+print_metric_if_exists() {
+    # Like print_metric, but prints nothing if no file exists.
+    # Args: label, stem, jq_filter, scale
+    local label="$1"
+    local stem="$2"
+    local jq_filter="$3"
+    local scale="${4:-1}"
+
+    local file
+    file="$(pick_file "$stem")"
+    [ -z "$file" ] && return 0
+
+    print_metric "$label" "$stem" "$jq_filter" "$scale"
+}
+
+# --- core English benchmarks ---
+print_metric "    arc_challenge: " "arc_challenge" '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' 100
+print_metric_if_exists "   arc_challenge2: " "arc_challenge2" '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' 100
+
+print_metric "        hellaswag: " "hellaswag" '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' 100
+print_metric_if_exists "       hellaswag2: " "hellaswag2" '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' 100
+
+print_metric "       goldenswag: " "goldenswag" '.results.goldenswag.acc_norm // .results.goldenswag["acc_norm,none"]' 100
+
+# mmlu is special: historically either .results.mmlu["acc,none"] or per-subtask .results[].acc
 echo -n "             mmlu: "
-if [ -f $DIR/mmlu.json ] ; then
-    cat $DIR/mmlu.json | jq '[if .results.mmlu | has("acc,none") then .results.mmlu["acc,none"] else .results | .[] | .acc end] | add / length * 100'
-elif [ -f $DIR/vllm_mmlu.json ] ; then
-    cat $DIR/vllm_mmlu.json | jq '[if .results.mmlu | has("acc,none") then .results.mmlu["acc,none"] else .results | .[] | .acc end] | add / length * 100'
+mmlu_file="$(pick_file "mmlu")"
+if [ -n "$mmlu_file" ]; then
+    jq -r '[if (.results.mmlu? | has("acc,none")) then .results.mmlu["acc,none"] else (.results | .[] | .acc) end] | add / length * 100' "$mmlu_file" 2>/dev/null \
+        | awk '{print $1}'
 else
     echo na
 fi
-if [ -f $DIR/mmlu2.json ] ; then
-    echo -n "            mmlu2: "
-    cat $DIR/mmlu2.json | jq '.results.mmlu."acc,none"' | awk '{print $1 * 100}'
-fi
+print_metric_if_exists "            mmlu2: " "mmlu2" '.results.mmlu."acc,none"' 100
 
-echo -n "    truthfulqa_mc: "
-if [ -f $DIR/truthfulqa_mc.json ] ; then 
-    cat $DIR/truthfulqa_mc.json | jq '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc2["acc,none"]' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_truthfulqa_mc.json ] ; then 
-    cat $DIR/vllm_truthfulqa_mc.json | jq '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc2["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/truthfulqa_mc2.json ] ; then 
-    echo -n "   truthfulqa_mc2: "
-    cat $DIR/truthfulqa_mc.json | jq '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc2["acc,none"]' | awk '{print $1 * 100}'
-fi
+# truthfulqa_mc: keep original fallbacks but avoid cat|jq and allow timestamped/vllm names
+print_metric "    truthfulqa_mc: " "truthfulqa_mc" '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc["acc,none"] // .results.truthfulqa_mc2["acc,none"]' 100
+print_metric_if_exists "   truthfulqa_mc2: " "truthfulqa_mc2" '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc["acc,none"] // .results.truthfulqa_mc2["acc,none"]' 100
 
-echo -n "       winogrande: "
-if [ -f $DIR/winogrande.json ] ; then
-   cat $DIR/winogrande.json | jq '.results.winogrande.acc // .results.winogrande["acc,none"]' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_winogrande.json ] ; then
-   cat $DIR/vllm_winogrande.json | jq '.results.winogrande.acc // .results.winogrande["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/winogrande2.json ] ; then
-    echo -n "      winogrande2: "
-   cat $DIR/winogrande2.json | jq '.results.winogrande.acc // .results.winogrande["acc,none"]' | awk '{print $1 * 100}'
-fi
+print_metric "       winogrande: " "winogrande" '.results.winogrande.acc // .results.winogrande["acc,none"]' 100
+print_metric_if_exists "      winogrande2: " "winogrande2" '.results.winogrande.acc // .results.winogrande["acc,none"]' 100
 
-echo -n "            gsm8k: "
-if [ -f $DIR/gsm8k.json ] ; then
-    cat $DIR/gsm8k.json | jq '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_gsm8k.json ] ; then
-    cat $DIR/vllm_gsm8k.json | jq '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/gsm8k2.json ] ; then
-    echo -n "           gsm8k2: "
-    cat $DIR/gsm8k2.json | jq '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' | awk '{print $1 * 100}'
-fi
+print_metric "            gsm8k: " "gsm8k" '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' 100
+print_metric_if_exists "           gsm8k2: " "gsm8k2" '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' 100
 
 echo
 
+# --- finbench (needs content sniff) ---
 echo -n "     finbench_3shot: "
-if [ -f $DIR/finbench_3shot.json ] ; then 
-    if grep FIN-bench $DIR/finbench_3shot.json > /dev/null 2>&1 ; then 
-        # new version
-        cat $DIR/finbench_3shot.json | jq  '.results | to_entries | map(.value."acc,none") | add / length' | awk '{print $1 * 100}'
+fin_file="$(pick_file "finbench_3shot")"
+if [ -z "$fin_file" ]; then
+    echo na
+else
+    if grep -q "FIN-bench" "$fin_file" >/dev/null 2>&1; then
+        jq -r '.results | to_entries | map(.value."acc,none") | add / length' "$fin_file" 2>/dev/null | awk '{print $1 * 100}'
     else
-        # old version
-        cat $DIR/finbench_3shot.json | jq  '.results | 
+        jq -r '.results |
             [
             .bigbench_1_digit_addition.multiple_choice_grade,
             .bigbench_1_digit_division.multiple_choice_grade,
@@ -151,569 +244,163 @@ if [ -f $DIR/finbench_3shot.json ] ; then
         ]
         } | {
         overall_average: ((.other) | add / length)
-        } | .overall_average' | awk '{print $1 * 100}'
+        } | .overall_average' "$fin_file" 2>/dev/null | awk '{print $1 * 100}'
     fi
-
-else
-    echo na
 fi
 
-echo -n "   arc_challenge_fi: "
-if [ -f $DIR/arc_challenge_fi.json ] ; then 
-    cat $DIR/arc_challenge_fi.json | jq '.results.arc_challenge_fi.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_fi.json ] ; then 
-    cat $DIR/arc_challenge_mt_fi.json | jq '.results.arc_challenge_mt_fi["acc_norm,none"]' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_arc_challenge_fi.json ] ; then 
-    cat $DIR/vllm_arc_challenge_fi.json | jq '.results.arc_challenge_fi.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_arc_challenge_mt_fi.json ] ; then 
-    cat $DIR/vllm_arc_challenge_mt_fi.json | jq '.results.arc_challenge_mt_fi["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    hellaswag_mt_fi: "
-if [ -f $DIR/hellaswag_mt_fi.json ] ; then
-    cat $DIR/hellaswag_mt_fi.json | jq '.results.ogx_hellaswagx_fi."acc,none"' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_hellaswag_mt_fi.json ] ; then
-    cat $DIR/vllm_hellaswag_mt_fi.json | jq '.results.ogx_hellaswagx_fi."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n "    goldenswag_mt_fi: "
-if [ -f $DIR/goldenswag_mt_fi.json ] ; then
-    cat $DIR/goldenswag_mt_fi.json | jq '.results.ogx_goldenswagx_fi."acc,none"' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_goldenswag_mt_fi.json ] ; then
-    cat $DIR/vllm_goldenswag_mt_fi.json | jq '.results.ogx_goldenswagx_fi."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "         mmlu_mt_fi: "
-if [ -f $DIR/mmlu_mt_fi.json ] ; then
-    cat $DIR/mmlu_mt_fi.json | jq '.groups.ogx_mmlux_FI."acc,none"' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_mmlu_mt_fi.json ] ; then
-    cat $DIR/vllm_mmlu_mt_fi.json | jq '.groups.ogx_mmlux_FI."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "truthfulqa_mc_mt_fi: "
-if [ -f $DIR/truthfulqa_mc_mt_fi.json ] ; then
-    cat $DIR/truthfulqa_mc_mt_fi.json | jq '.results.ogx_truthfulqax_mc2_fi."acc,none"' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_truthfulqa_mc_mt_fi.json ] ; then
-    cat $DIR/vllm_truthfulqa_mc_mt_fi.json | jq '.results.ogx_truthfulqax_mc2_fi."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "        gsm8k_mt_fi: "
-if [ -f $DIR/gsm8k_mt_fi.json ] ; then
-    cat $DIR/gsm8k_mt_fi.json | jq '.results.ogx_gsm8kx_fi."acc,none"' | awk '{print $1 * 100}'
-elif [ -f $DIR/vllm_gsm8k_mt_fi.json ] ; then
-    cat $DIR/vllm_gsm8k_mt_fi.json | jq '.results.ogx_gsm8kx_fi."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
+# --- Finnish MT suite ---
+print_metric "   arc_challenge_fi: " "arc_challenge_mt_fi" '.results.arc_challenge_fi.acc_norm // .results.arc_challenge_mt_fi["acc_norm,none"] // .results.arc_challenge_fi["acc_norm,none"]' 100
+print_metric "    hellaswag_mt_fi: " "hellaswag_mt_fi" '.results.ogx_hellaswagx_fi."acc,none"' 100
+print_metric "    goldenswag_mt_fi: " "goldenswag_mt_fi" '.results.ogx_goldenswagx_fi."acc,none"' 100
+print_metric "         mmlu_mt_fi: " "mmlu_mt_fi" '.groups.ogx_mmlux_FI."acc,none"' 100
+print_metric "truthfulqa_mc_mt_fi: " "truthfulqa_mc_mt_fi" '.results.ogx_truthfulqax_mc2_fi."acc,none"' 100
+print_metric "        gsm8k_mt_fi: " "gsm8k_mt_fi" '.results.ogx_gsm8kx_fi."acc,none"' 100
 
 echo
 
-echo -n "    flores200_en_fi bleu: "
-if [ -f $DIR/flores200_trans_en_fi.json ] ; then
-    cat $DIR/flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-elif [ -f $DIR/vllm_flores200_trans_en_fi.json ] ; then
-    cat $DIR/vllm_flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+print_metric "    flores200_en_fi bleu: " "flores200_trans_en_fi" '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_fi_en bleu: " "flores200_trans_fi_en" '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_en_fi chrf: " "flores200_trans_en_fi" '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."chrf,none"' 1
+print_metric "    flores200_fi_en chrf: " "flores200_trans_fi_en" '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."chrf,none"' 1
 
-echo -n "    flores200_fi_en bleu: "
-if [ -f $DIR/flores200_trans_fi_en.json ] ; then
-    cat $DIR/flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-elif [ -f $DIR/vllm_flores200_trans_fi_en.json ] ; then
-    cat $DIR/vllm_flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+echo
+# --- Danish MT suite ---
+print_metric "   arc_challenge_da: " "arc_challenge_da" '.results.arc_challenge_da.acc_norm // .results.arc_challenge_mt_da["acc_norm,none"] // .results.arc_challenge_da["acc_norm,none"]' 100
+print_metric "    hellaswag_mt_da: " "hellaswag_mt_da" '.results.ogx_hellaswagx_da."acc,none"' 100
+print_metric "         mmlu_mt_da: " "mmlu_mt_da" '.groups.ogx_mmlux_DA."acc,none"' 100
+print_metric "truthfulqa_mc_mt_da: " "truthfulqa_mc_mt_da" '.results.ogx_truthfulqax_mc2_da."acc,none"' 100
+print_metric "        gsm8k_mt_da: " "gsm8k_mt_da" '.results.ogx_gsm8kx_da."acc,none"' 100
+print_metric "    flores200_en_da: " "flores200_trans_en_da" '.results."ogx_flores200-trans-eng_Latn-dan_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_da_en: " "flores200_trans_da_en" '.results."ogx_flores200-trans-dan_Latn-eng_Latn"."bleu_flores200,none"' 1
 
-echo -n "    flores200_en_fi chrf: "
-if [ -f $DIR/flores200_trans_en_fi.json ] ; then
-    cat $DIR/flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
-elif [ -f $DIR/vllm_flores200_trans_en_fi.json ] ; then
-    cat $DIR/vllm_flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+echo
+# --- Icelandic ---
+print_metric " arc_challenge_is: " "arc_challenge_is" '.results.arc_challenge_is.acc_norm // .results.arc_challenge_mt_is["acc_norm,none"] // .results.arc_challenge_is["acc_norm,none"]' 100
+print_metric "    flores200_en_is: " "flores200_trans_en_is" '.results."ogx_flores200-trans-eng_Latn-isl_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_is_en: " "flores200_trans_is_en" '.results."ogx_flores200-trans-isl_Latn-eng_Latn"."bleu_flores200,none"' 1
 
-echo -n "    flores200_fi_en chrf: "
-if [ -f $DIR/flores200_trans_fi_en.json ] ; then
-    cat $DIR/flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
-elif [ -f $DIR/vllm_flores200_trans_fi_en.json ] ; then
-    cat $DIR/vllm_flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+echo
+# --- Norwegian Bokmål ---
+print_metric " arc_challenge_nb: " "arc_challenge_nb" '.results.arc_challenge_nb.acc_norm // .results.arc_challenge_mt_nb["acc_norm,none"] // .results.arc_challenge_nb["acc_norm,none"]' 100
+print_metric "    flores200_en_nb: " "flores200_trans_en_nb" '.results."ogx_flores200-trans-eng_Latn-nob_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_nb_en: " "flores200_trans_nb_en" '.results."ogx_flores200-trans-nob_Latn-eng_Latn"."bleu_flores200,none"' 1
 
+echo
+# --- Swedish ---
+print_metric "   arc_challenge_sv: " "arc_challenge_sv" '.results.arc_challenge_sv.acc_norm // .results.arc_challenge_mt_sv["acc_norm,none"] // .results.arc_challenge_sv["acc_norm,none"]' 100
+print_metric "    hellaswag_mt_sv: " "hellaswag_mt_sv" '.results.ogx_hellaswagx_sv."acc,none"' 100
+print_metric "         mmlu_mt_sv: " "mmlu_mt_sv" '.groups.ogx_mmlux_SV."acc,none"' 100
+print_metric "truthfulqa_mc_mt_sv: " "truthfulqa_mc_mt_sv" '.results.ogx_truthfulqax_mc2_sv."acc,none"' 100
+print_metric "        gsm8k_mt_sv: " "gsm8k_mt_sv" '.results.ogx_gsm8kx_sv."acc,none"' 100
+print_metric "    flores200_en_sv: " "flores200_trans_en_sv" '.results."ogx_flores200-trans-eng_Latn-swe_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_sv_en: " "flores200_trans_sv_en" '.results."ogx_flores200-trans-swe_Latn-eng_Latn"."bleu_flores200,none"' 1
+
+echo
+# --- arc_challenge (other languages) ---
+print_metric " arc_challenge_de: " "arc_challenge_de" '.results.arc_challenge_de.acc_norm // .results.arc_challenge_mt_de["acc_norm,none"] // .results.arc_challenge_de["acc_norm,none"]' 100
+print_metric " arc_challenge_el: " "arc_challenge_el" '.results.arc_challenge_el.acc_norm // .results.arc_challenge_mt_el["acc_norm,none"] // .results.arc_challenge_el["acc_norm,none"]' 100
+print_metric " arc_challenge_es: " "arc_challenge_es" '.results.arc_challenge_es.acc_norm // .results.arc_challenge_mt_es["acc_norm,none"] // .results.arc_challenge_es["acc_norm,none"]' 100
+print_metric " arc_challenge_fr: " "arc_challenge_fr" '.results.arc_challenge_fr.acc_norm // .results.arc_challenge_mt_fr["acc_norm,none"] // .results.arc_challenge_fr["acc_norm,none"]' 100
+print_metric " arc_challenge_hu: " "arc_challenge_hu" '.results.arc_challenge_hu.acc_norm // .results.arc_challenge_mt_hu["acc_norm,none"] // .results.arc_challenge_hu["acc_norm,none"]' 100
+print_metric " arc_challenge_it: " "arc_challenge_it" '.results.arc_challenge_it.acc_norm // .results.arc_challenge_mt_it["acc_norm,none"] // .results.arc_challenge_it["acc_norm,none"]' 100
+print_metric " arc_challenge_nl: " "arc_challenge_nl" '.results.arc_challenge_nl.acc_norm // .results.arc_challenge_mt_nl["acc_norm,none"] // .results.arc_challenge_nl["acc_norm,none"]' 100
+print_metric " arc_challenge_pl: " "arc_challenge_pl" '.results.arc_challenge_pl.acc_norm // .results.arc_challenge_mt_pl["acc_norm,none"] // .results.arc_challenge_pl["acc_norm,none"]' 100
+print_metric " arc_challenge_pt: " "arc_challenge_pt" '.results.arc_challenge_pt.acc_norm // .results.arc_challenge_mt_pt["acc_norm,none"] // .results.arc_challenge_pt["acc_norm,none"]' 100
+
+echo
+print_metric " arc_challenge_bg: " "arc_challenge_bg" '.results.arc_challenge_bg.acc_norm // .results.arc_challenge_mt_bg["acc_norm,none"] // .results.arc_challenge_bg["acc_norm,none"]' 100
+print_metric " arc_challenge_cs: " "arc_challenge_cs" '.results.arc_challenge_cs.acc_norm // .results.arc_challenge_mt_cs["acc_norm,none"] // .results.arc_challenge_cs["acc_norm,none"]' 100
+print_metric " arc_challenge_et: " "arc_challenge_et" '.results.arc_challenge_et.acc_norm // .results.arc_challenge_mt_et["acc_norm,none"] // .results.arc_challenge_et["acc_norm,none"]' 100
+print_metric " arc_challenge_lt: " "arc_challenge_lt" '.results.arc_challenge_lt.acc_norm // .results.arc_challenge_mt_lt["acc_norm,none"] // .results.arc_challenge_lt["acc_norm,none"]' 100
+print_metric " arc_challenge_lv: " "arc_challenge_lv" '.results.arc_challenge_lv.acc_norm // .results.arc_challenge_mt_lv["acc_norm,none"] // .results.arc_challenge_lv["acc_norm,none"]' 100
+print_metric " arc_challenge_ro: " "arc_challenge_ro" '.results.arc_challenge_ro.acc_norm // .results.arc_challenge_mt_ro["acc_norm,none"] // .results.arc_challenge_ro["acc_norm,none"]' 100
+print_metric " arc_challenge_sk: " "arc_challenge_sk" '.results.arc_challenge_sk.acc_norm // .results.arc_challenge_mt_sk["acc_norm,none"] // .results.arc_challenge_sk["acc_norm,none"]' 100
+print_metric " arc_challenge_sl: " "arc_challenge_sl" '.results.arc_challenge_sl.acc_norm // .results.arc_challenge_mt_sl["acc_norm,none"] // .results.arc_challenge_sl["acc_norm,none"]' 100
+
+echo
+# --- code tasks ---
+print_metric " humaneval-unstripped_pass@1: " "humaneval-unstripped_pass@1" '."humaneval-unstripped"."pass@1"' 100
+print_metric "humaneval-unstripped_pass@10: " "humaneval-unstripped_pass@10" '."humaneval-unstripped"."pass@10"' 100
+print_metric " humaneval_pass@1: " "humaneval_pass@1" '.humaneval."pass@1"' 100
+print_metric "humaneval_pass@10: " "humaneval_pass@10" '.humaneval."pass@10"' 100
+print_metric "      mbpp_pass@1: " "mbpp_pass@1" '.mbpp."pass@1"' 100
+print_metric "     mbpp_pass@10: " "mbpp_pass@10" '.mbpp."pass@10"' 100
 
 echo
 
-echo -n "   arc_challenge_da: "
-if [ -f $DIR/arc_challenge_da.json ] ; then 
-    cat $DIR/arc_challenge_da.json | jq '.results.arc_challenge_da.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_da.json ] ; then 
-    cat $DIR/arc_challenge_mt_da.json | jq '.results.arc_challenge_mt_da["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    hellaswag_mt_da: "
-if [ -f $DIR/hellaswag_mt_da.json ] ; then
-    cat $DIR/hellaswag_mt_da.json | jq '.results.ogx_hellaswagx_da."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "         mmlu_mt_da: "
-if [ -f $DIR/mmlu_mt_da.json ] ; then
-    cat $DIR/mmlu_mt_da.json | jq '.groups.ogx_mmlux_DA."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "truthfulqa_mc_mt_da: "
-if [ -f $DIR/truthfulqa_mc_mt_da.json ] ; then
-    cat $DIR/truthfulqa_mc_mt_da.json | jq '.results.ogx_truthfulqax_mc2_da."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "        gsm8k_mt_da: "
-if [ -f $DIR/gsm8k_mt_da.json ] ; then
-    cat $DIR/gsm8k_mt_da.json | jq '.results.ogx_gsm8kx_da."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    flores200_en_da: "
-if [ -f $DIR/flores200_trans_en_da.json ] ; then
-    cat $DIR/flores200_trans_en_da.json | jq '.results."ogx_flores200-trans-eng_Latn-dan_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo -n "    flores200_da_en: "
-if [ -f $DIR/flores200_trans_da_en.json ] ; then
-    cat $DIR/flores200_trans_da_en.json | jq '.results."ogx_flores200-trans-dan_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+# --- misc QA / reasoning ---
+print_metric "         arc_easy: " "arc_easy" '.results.arc_easy.acc // .results.arc_easy["acc,none"]' 100
+print_metric "            boolq: " "boolq" '.results.boolq.acc // .results.boolq["acc,none"]' 100
+print_metric "          nq_open: " "nq_open" '.results.nq_open.em // .results.nq_open["exact_match,remove_whitespace"]' 100
+print_metric " openbookqa (acc): " "openbookqa" '.results.openbookqa.acc // .results.openbookqa["acc,none"]' 100
+print_metric "       piqa (acc): " "piqa" '.results.piqa.acc // .results.piqa["acc,none"]' 100
+print_metric "      squad2 (f1): " "squad2" '.results.squad2.f1 // .results.squadv2["f1,none"]' 1
+print_metric "         triviaqa: " "triviaqa" '.results.triviaqa.em // .results.triviaqa["exact_match,remove_whitespace"]' 100
 
 echo
 
-echo -n " arc_challenge_is: "
-if [ -f $DIR/arc_challenge_is.json ] ; then 
-    cat $DIR/arc_challenge_is.json | jq '.results.arc_challenge_is.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_is.json ] ; then 
-    cat $DIR/arc_challenge_mt_is.json | jq '.results.arc_challenge_mt_is["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
+# --- safety / other ---
+print_metric "    toxigen (acc): " "toxigen" '.results.toxigen.acc // .results.toxigen["acc,none"]' 100
 
-echo -n "    flores200_en_is: "
-if [ -f $DIR/flores200_trans_en_is.json ] ; then
-    cat $DIR/flores200_trans_en_is.json | jq '.results."ogx_flores200-trans-eng_Latn-isl_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo -n "    flores200_is_en: "
-if [ -f $DIR/flores200_trans_is_en.json ] ; then
-    cat $DIR/flores200_trans_is_en.json | jq '.results."ogx_flores200-trans-isl_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo
-
-
-echo -n " arc_challenge_nb: "
-if [ -f $DIR/arc_challenge_nb.json ] ; then 
-    cat $DIR/arc_challenge_nb.json | jq '.results.arc_challenge_nb.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_nb.json ] ; then 
-    cat $DIR/arc_challenge_mt_nb.json | jq '.results.arc_challenge_mt_nb["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    flores200_en_nb: "
-if [ -f $DIR/flores200_trans_en_nb.json ] ; then
-    cat $DIR/flores200_trans_en_nb.json | jq '.results."ogx_flores200-trans-eng_Latn-nob_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo -n "    flores200_nb_en: "
-if [ -f $DIR/flores200_trans_nb_en.json ] ; then
-    cat $DIR/flores200_trans_nb_en.json | jq '.results."ogx_flores200-trans-nob_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo 
-
-echo -n "   arc_challenge_sv: "
-if [ -f $DIR/arc_challenge_sv.json ] ; then 
-    cat $DIR/arc_challenge_sv.json | jq '.results.arc_challenge_sv.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_sv.json ] ; then 
-    cat $DIR/arc_challenge_mt_sv.json | jq '.results.arc_challenge_mt_sv["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    hellaswag_mt_sv: "
-if [ -f $DIR/hellaswag_mt_sv.json ] ; then
-    cat $DIR/hellaswag_mt_sv.json | jq '.results.ogx_hellaswagx_sv."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "         mmlu_mt_sv: "
-if [ -f $DIR/mmlu_mt_sv.json ] ; then
-    cat $DIR/mmlu_mt_sv.json | jq '.groups.ogx_mmlux_SV."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "truthfulqa_mc_mt_sv: "
-if [ -f $DIR/truthfulqa_mc_mt_sv.json ] ; then
-    cat $DIR/truthfulqa_mc_mt_sv.json | jq '.results.ogx_truthfulqax_mc2_sv."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "        gsm8k_mt_sv: "
-if [ -f $DIR/gsm8k_mt_sv.json ] ; then
-    cat $DIR/gsm8k_mt_sv.json | jq '.results.ogx_gsm8kx_sv."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    flores200_en_sv: "
-if [ -f $DIR/flores200_trans_en_sv.json ] ; then
-    cat $DIR/flores200_trans_en_sv.json | jq '.results."ogx_flores200-trans-eng_Latn-swe_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo -n "    flores200_sv_en: "
-if [ -f $DIR/flores200_trans_sv_en.json ] ; then
-    cat $DIR/flores200_trans_sv_en.json | jq '.results."ogx_flores200-trans-swe_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo
-
-echo -n " arc_challenge_de: "
-if [ -f $DIR/arc_challenge_de.json ] ; then
-    cat $DIR/arc_challenge_de.json | jq '.results.arc_challenge_de.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_de.json ] ; then 
-    cat $DIR/arc_challenge_mt_de.json | jq '.results.arc_challenge_mt_de["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_el: "
-if [ -f $DIR/arc_challenge_el.json ] ; then
-    cat $DIR/arc_challenge_el.json | jq '.results.arc_challenge_el.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_el.json ] ; then 
-    cat $DIR/arc_challenge_mt_el.json | jq '.results.arc_challenge_mt_el["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_es: "
-if [ -f $DIR/arc_challenge_es.json ] ; then
-    cat $DIR/arc_challenge_es.json | jq '.results.arc_challenge_es.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_es.json ] ; then 
-    cat $DIR/arc_challenge_mt_es.json | jq '.results.arc_challenge_mt_es["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_fr: "
-if [ -f $DIR/arc_challenge_fr.json ] ; then
-    cat $DIR/arc_challenge_fr.json | jq '.results.arc_challenge_fr.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_fr.json ] ; then 
-    cat $DIR/arc_challenge_mt_fr.json | jq '.results.arc_challenge_mt_fr["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_hu: "
-if [ -f $DIR/arc_challenge_hu.json ] ; then
-    cat $DIR/arc_challenge_hu.json | jq '.results.arc_challenge_hu.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_hu.json ] ; then 
-    cat $DIR/arc_challenge_mt_hu.json | jq '.results.arc_challenge_mt_hu["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_it: "
-if [ -f $DIR/arc_challenge_it.json ] ; then
-    cat $DIR/arc_challenge_it.json | jq '.results.arc_challenge_it.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_it.json ] ; then 
-    cat $DIR/arc_challenge_mt_it.json | jq '.results.arc_challenge_mt_it["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_nl: "
-if [ -f $DIR/arc_challenge_nl.json ] ; then
-    cat $DIR/arc_challenge_nl.json | jq '.results.arc_challenge_nl.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_nl.json ] ; then 
-    cat $DIR/arc_challenge_mt_nl.json | jq '.results.arc_challenge_mt_nl["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_pl: "
-if [ -f $DIR/arc_challenge_pl.json ] ; then
-    cat $DIR/arc_challenge_pl.json | jq '.results.arc_challenge_pl.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_pl.json ] ; then 
-    cat $DIR/arc_challenge_mt_pl.json | jq '.results.arc_challenge_mt_pl["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_pt: "
-if [ -f $DIR/arc_challenge_pt.json ] ; then
-    cat $DIR/arc_challenge_pt.json | jq '.results.arc_challenge_pt.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_pt.json ] ; then 
-    cat $DIR/arc_challenge_mt_pt.json | jq '.results.arc_challenge_mt_pt["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo
-
-echo -n " arc_challenge_bg: "
-if [ -f $DIR/arc_challenge_bg.json ] ; then
-    cat $DIR/arc_challenge_bg.json | jq '.results.arc_challenge_bg.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_bg.json ] ; then 
-    cat $DIR/arc_challenge_mt_bg.json | jq '.results.arc_challenge_mt_bg["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_cs: "
-if [ -f $DIR/arc_challenge_cs.json ] ; then
-    cat $DIR/arc_challenge_cs.json | jq '.results.arc_challenge_cs.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_cs.json ] ; then 
-    cat $DIR/arc_challenge_mt_cs.json | jq '.results.arc_challenge_mt_cs["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_et: "
-if [ -f $DIR/arc_challenge_et.json ] ; then
-    cat $DIR/arc_challenge_et.json | jq '.results.arc_challenge_et.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_et.json ] ; then 
-    cat $DIR/arc_challenge_mt_et.json | jq '.results.arc_challenge_mt_et["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_lt: "
-if [ -f $DIR/arc_challenge_lt.json ] ; then
-    cat $DIR/arc_challenge_lt.json | jq '.results.arc_challenge_lt.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_lt.json ] ; then 
-    cat $DIR/arc_challenge_mt_lt.json | jq '.results.arc_challenge_mt_lt["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_lv: "
-if [ -f $DIR/arc_challenge_lv.json ] ; then
-    cat $DIR/arc_challenge_lv.json | jq '.results.arc_challenge_lv.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_lv.json ] ; then 
-    cat $DIR/arc_challenge_mt_lv.json | jq '.results.arc_challenge_mt_lv["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_ro: "
-if [ -f $DIR/arc_challenge_ro.json ] ; then
-    cat $DIR/arc_challenge_ro.json | jq '.results.arc_challenge_ro.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_ro.json ] ; then 
-    cat $DIR/arc_challenge_mt_ro.json | jq '.results.arc_challenge_mt_ro["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_sk: "
-if [ -f $DIR/arc_challenge_sk.json ] ; then
-    cat $DIR/arc_challenge_sk.json | jq '.results.arc_challenge_sk.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_sk.json ] ; then 
-    cat $DIR/arc_challenge_mt_sk.json | jq '.results.arc_challenge_mt_sk["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_sl: "
-if [ -f $DIR/arc_challenge_sl.json ] ; then
-    cat $DIR/arc_challenge_sl.json | jq '.results.arc_challenge_sl.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_sl.json ] ; then 
-    cat $DIR/arc_challenge_mt_sl.json | jq '.results.arc_challenge_mt_sl["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo
-
-echo -n " humaneval-unstripped_pass@1: "
-if [ -f $DIR/humaneval-unstripped_pass@1.json ] ; then
-    cat $DIR/humaneval-unstripped_pass@1.json | jq '."humaneval-unstripped"."pass@1"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-
-echo -n "humaneval-unstripped_pass@10: "
-if [ -f $DIR/humaneval-unstripped_pass@10.json ] ; then
-    cat $DIR/humaneval-unstripped_pass@10.json | jq '."humaneval-unstripped"."pass@10"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-echo -n " humaneval_pass@1: "
-if [ -f $DIR/humaneval_pass@1.json ] ; then
-    cat $DIR/humaneval_pass@1.json | jq '.humaneval."pass@1"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-
-echo -n "humaneval_pass@10: "
-if [ -f $DIR/humaneval_pass@10.json ] ; then
-    cat $DIR/humaneval_pass@10.json | jq '.humaneval."pass@10"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-echo -n "      mbpp_pass@1: "
-if [ -f $DIR/mbpp_pass@1.json ] ; then
-    cat $DIR/mbpp_pass@1.json | jq '.mbpp."pass@1"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-
-echo -n "     mbpp_pass@10: "
-if [ -f $DIR/mbpp_pass@10.json ] ; then
-    cat $DIR/mbpp_pass@10.json | jq '.mbpp."pass@10"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-
-echo
-
-#   cat $DIR/winogrande2.json | jq '.results.winogrande.acc // .results.winogrande["acc,none"]' | awk '{print $1 * 100}'
-
-echo -n "         arc_easy: "
-if [ -f $DIR/arc_easy.json ] ; then
-    cat $DIR/arc_easy.json | jq '.results.arc_easy.acc // .results.arc_easy["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "            boolq: "
-if [ -f $DIR/boolq.json ] ; then
-    cat $DIR/boolq.json | jq '.results.boolq.acc // .results.boolq["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "          nq_open: "
-if [ -f $DIR/nq_open.json ] ; then
-    cat $DIR/nq_open.json | jq '.results.nq_open.em // .results.nq_open["exact_match,remove_whitespace"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " openbookqa (acc): "
-if [ -f $DIR/openbookqa.json ] ; then
-    cat $DIR/openbookqa.json | jq '.results.openbookqa.acc // .results.openbookqa["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "       piqa (acc): "
-if [ -f $DIR/piqa.json ] ; then
-    cat $DIR/piqa.json | jq '.results.piqa.acc // .results.piqa["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "      squad2 (f1): "
-if [ -f $DIR/squad2.json ] ; then
-    cat $DIR/squad2.json | jq '.results.squad2.f1 // .results.squadv2["f1,none"]'
-else
-    echo na
-fi
-
-echo -n "         triviaqa: "
-if [ -f $DIR/triviaqa.json ] ; then
-    cat $DIR/triviaqa.json | jq '.results.triviaqa.em // .results.triviaqa["exact_match,remove_whitespace"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo
-
-echo -n "    toxigen (acc): "
-if [ -f $DIR/toxigen.json ] ; then
-    cat $DIR/toxigen.json | jq '.results.toxigen.acc // .results.toxigen["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-if [ -f $DIR/belebele_fin.json ] ; then
+# Optional extras (print only if present; also support vllm/timestamped)
+bele_file="$(pick_file "belebele_fin")"
+if [ -n "$bele_file" ]; then
     echo
     echo -n "     belebele_fin: "
-    cat $DIR/belebele_fin.json | jq '.results.belebele_fin_Latn["acc,none"]' | awk '{print $1 * 100}'
+    jq -r '.results.belebele_fin_Latn["acc,none"]' "$bele_file" 2>/dev/null | awk '{print $1 * 100}'
 fi
 
-if [ -f $DIR/ifeval.json ] ; then
+ifeval_file="$(pick_file "ifeval")"
+if [ -n "$ifeval_file" ]; then
     echo
     echo -n "     ifeval prompt_loose: "
-    cat $DIR/ifeval.json | jq '.results.ifeval["prompt_level_loose_acc,none"]' | awk '{print $1 * 100}'
+    jq -r '.results.ifeval["prompt_level_loose_acc,none"]' "$ifeval_file" 2>/dev/null | awk '{print $1 * 100}'
 fi
 
-if [ -f $DIR/ifeval_fi.json ] ; then
+ifeval_fi_file="$(pick_file "ifeval_fi")"
+if [ -n "$ifeval_fi_file" ]; then
     echo -n "     ifeval_fi prompt_loose: "
-    cat $DIR/ifeval_fi.json | jq '.results.ifeval_fi["prompt_level_loose_acc,none"]' | awk '{print $1 * 100}'
+    jq -r '.results.ifeval_fi["prompt_level_loose_acc,none"]' "$ifeval_fi_file" 2>/dev/null | awk '{print $1 * 100}'
 fi
 
-if [ -f $DIR/multi_if.json ] ; then
+multi_if_file="$(pick_file "multi_if")"
+if [ -n "$multi_if_file" ]; then
     echo -n "     multi_if english_average: "
-    cat $DIR/multi_if.json | jq '.results.english_average'
+    jq -r '.results.english_average' "$multi_if_file" 2>/dev/null
 fi
 
-if [ -f $DIR/mtbench_judge_en.json ] ; then
+mtbench_en_file="$(pick_file "mtbench_judge_en")"
+if [ -n "$mtbench_en_file" ]; then
     echo -n "     mtbench_judge_en first_turn_score: "
-    cat $DIR/mtbench_judge_en.json | jq '.results.first_turn_score'
+    jq -r '.results.first_turn_score' "$mtbench_en_file" 2>/dev/null
 fi
 
-if [ -f $DIR/mtbench_judge_fi.json ] ; then
+mtbench_fi_file="$(pick_file "mtbench_judge_fi")"
+if [ -n "$mtbench_fi_file" ]; then
     echo -n "     mtbench_judge_fi first_turn_score: "
-    cat $DIR/mtbench_judge_fi.json | jq '.results.first_turn_score'
+    jq -r '.results.first_turn_score' "$mtbench_fi_file" 2>/dev/null
 fi
 
-if [ -f $DIR/mtbench_judge_en.json ] ; then
+if [ -n "$mtbench_en_file" ]; then
     echo -n "     mtbench_judge_en average_score: "
-    cat $DIR/mtbench_judge_en.json | jq '.results.average_score'
+    jq -r '.results.average_score' "$mtbench_en_file" 2>/dev/null
 fi
 
-if [ -f $DIR/mtbench_judge_fi.json ] ; then
+if [ -n "$mtbench_fi_file" ]; then
     echo -n "     mtbench_judge_fi average_score: "
-    cat $DIR/mtbench_judge_fi.json | jq '.results.average_score'
+    jq -r '.results.average_score' "$mtbench_fi_file" 2>/dev/null
 fi
 
-if [ -f $DIR/alpaca_eval_en.json ] ; then
+alpaca_en_file="$(pick_file "alpaca_eval_en")"
+if [ -n "$alpaca_en_file" ]; then
     echo -n "     alpaca_eval_en length_controlled_winrate: "
-    cat $DIR/alpaca_eval_en.json | jq '.results.length_controlled_winrate'
+    jq -r '.results.length_controlled_winrate' "$alpaca_en_file" 2>/dev/null
 fi
 
-if [ -f $DIR/alpaca_eval_fi.json ] ; then
+alpaca_fi_file="$(pick_file "alpaca_eval_fi")"
+if [ -n "$alpaca_fi_file" ]; then
     echo -n "     alpaca_eval_fi length_controlled_winrate: "
-    cat $DIR/alpaca_eval_fi.json | jq '.results.length_controlled_winrate'
+    jq -r '.results.length_controlled_winrate' "$alpaca_fi_file" 2>/dev/null
 fi
 
 echo

--- a/summary_ruler.sh
+++ b/summary_ruler.sh
@@ -25,20 +25,23 @@ SEQ_LENGTHS=(4096 8192 16384 32768 65536 131072)
 SEQ_LABELS=("4K" "8K" "16K" "32K" "64K" "128K")
 
 # Function to get result from a file
-# Args: filename, metric_key
+# Args: filename, subtask, seqlen
 get_result() {
     local file="$1"
     local subtask="$2"
+    local seqlen="$3"
     
     if [ ! -f "$file" ]; then
         echo "na"
         return
     fi
     
-    # Try different possible metric keys based on task type
-    # First try the main result key with acc,none or exact_match,none
+    # RULER results use sequence length in the key name: "<seqlen>,none"
+    # Try multiple possible key formats
     local result=$(cat "$file" | jq -r "
-        if .results[\"$subtask\"][\"acc,none\"] then 
+        if .results[\"$subtask\"][\"${seqlen},none\"] then 
+            .results[\"$subtask\"][\"${seqlen},none\"] * 100
+        elif .results[\"$subtask\"][\"acc,none\"] then 
             .results[\"$subtask\"][\"acc,none\"] * 100
         elif .results[\"$subtask\"][\"exact_match,none\"] then 
             .results[\"$subtask\"][\"exact_match,none\"] * 100
@@ -106,7 +109,7 @@ for subtask in "${NIAH_SINGLE[@]}"; do
     for i in "${!SEQ_LENGTHS[@]}"; do
         seqlen="${SEQ_LENGTHS[$i]}"
         file=$(find_file "$subtask" "$seqlen")
-        result=$(get_result "$file" "$subtask")
+        result=$(get_result "$file" "$subtask" "$seqlen")
         printf "%8s" "$result"
     done
     echo ""
@@ -120,7 +123,7 @@ for subtask in "${NIAH_MULTI[@]}"; do
     for i in "${!SEQ_LENGTHS[@]}"; do
         seqlen="${SEQ_LENGTHS[$i]}"
         file=$(find_file "$subtask" "$seqlen")
-        result=$(get_result "$file" "$subtask")
+        result=$(get_result "$file" "$subtask" "$seqlen")
         printf "%8s" "$result"
     done
     echo ""
@@ -134,7 +137,7 @@ for subtask in "${OTHER_TASKS[@]}"; do
     for i in "${!SEQ_LENGTHS[@]}"; do
         seqlen="${SEQ_LENGTHS[$i]}"
         file=$(find_file "$subtask" "$seqlen")
-        result=$(get_result "$file" "$subtask")
+        result=$(get_result "$file" "$subtask" "$seqlen")
         printf "%8s" "$result"
     done
     echo ""
@@ -158,7 +161,7 @@ for i in "${!SEQ_LENGTHS[@]}"; do
     scores=()
     for subtask in "${ALL_SUBTASKS[@]}"; do
         file=$(find_file "$subtask" "$seqlen")
-        result=$(get_result "$file" "$subtask")
+        result=$(get_result "$file" "$subtask" "$seqlen")
         if [ "$result" != "na" ]; then
             scores+=("$result")
         fi
@@ -204,7 +207,7 @@ for category_name in "NIAH Single" "NIAH Multi" "Other Tasks" "Overall"; do
         scores=()
         for subtask in "${tasks[@]}"; do
             file=$(find_file "$subtask" "$seqlen")
-            result=$(get_result "$file" "$subtask")
+            result=$(get_result "$file" "$subtask" "$seqlen")
             if [ "$result" != "na" ]; then
                 scores+=("$result")
             fi

--- a/summary_ruler.sh
+++ b/summary_ruler.sh
@@ -24,56 +24,126 @@ ALL_SUBTASKS=("${NIAH_SINGLE[@]}" "${NIAH_MULTI[@]}" "${OTHER_TASKS[@]}")
 SEQ_LENGTHS=(4096 8192 16384 32768 65536 131072)
 SEQ_LABELS=("4K" "8K" "16K" "32K" "64K" "128K")
 
-# Function to get result from a file
-# Args: filename, subtask, seqlen
 get_result() {
     local file="$1"
     local subtask="$2"
     local seqlen="$3"
-    
-    if [ ! -f "$file" ]; then
+
+    # Treat missing OR empty files as no result.
+    if [ -z "$file" ] || [ ! -s "$file" ]; then
         echo "na"
         return
     fi
-    
-    # RULER results use sequence length in the key name: "<seqlen>,none"
-    # Try multiple possible key formats
-    local result=$(cat "$file" | jq -r "
-        if .results[\"$subtask\"][\"${seqlen},none\"] then 
+
+    # Call jq directly (avoid cat|jq pipeline).
+    local result
+    result=$(jq -r "
+        if .results[\"$subtask\"][\"${seqlen},none\"] then
             .results[\"$subtask\"][\"${seqlen},none\"] * 100
-        elif .results[\"$subtask\"][\"acc,none\"] then 
+        elif .results[\"$subtask\"][\"acc,none\"] then
             .results[\"$subtask\"][\"acc,none\"] * 100
-        elif .results[\"$subtask\"][\"exact_match,none\"] then 
+        elif .results[\"$subtask\"][\"exact_match,none\"] then
             .results[\"$subtask\"][\"exact_match,none\"] * 100
-        elif .results[\"$subtask\"].acc then 
+        elif .results[\"$subtask\"].acc then
             .results[\"$subtask\"].acc * 100
-        elif .results[\"$subtask\"].exact_match then 
+        elif .results[\"$subtask\"].exact_match then
             .results[\"$subtask\"].exact_match * 100
-        else 
-            \"na\" 
+        else
+            \"na\"
         end
-    " 2>/dev/null)
-    
-    if [ "$result" == "null" ] || [ "$result" == "na" ] || [ -z "$result" ]; then
+    " "$file" 2>/dev/null)
+
+    if [ "$result" = "null" ] || [ "$result" = "na" ] || [ -z "$result" ]; then
         echo "na"
     else
         printf "%.2f" "$result"
     fi
 }
 
-# Function to find the file (check both regular and vllm prefix)
+# Function to get result from a file
+# Args: filename, subtask, seqlen
+# get_result() {
+#     local file="$1"
+#     local subtask="$2"
+#     local seqlen="$3"
+    
+#     if [ ! -f "$file" ]; then
+#         echo "na"
+#         return
+#     fi
+    
+#     # RULER results use sequence length in the key name: "<seqlen>,none"
+#     # Try multiple possible key formats
+#     local result=$(cat "$file" | jq -r "
+#         if .results[\"$subtask\"][\"${seqlen},none\"] then 
+#             .results[\"$subtask\"][\"${seqlen},none\"] * 100
+#         elif .results[\"$subtask\"][\"acc,none\"] then 
+#             .results[\"$subtask\"][\"acc,none\"] * 100
+#         elif .results[\"$subtask\"][\"exact_match,none\"] then 
+#             .results[\"$subtask\"][\"exact_match,none\"] * 100
+#         elif .results[\"$subtask\"].acc then 
+#             .results[\"$subtask\"].acc * 100
+#         elif .results[\"$subtask\"].exact_match then 
+#             .results[\"$subtask\"].exact_match * 100
+#         else 
+#             \"na\" 
+#         end
+#     " 2>/dev/null)
+    
+#     if [ "$result" == "null" ] || [ "$result" == "na" ] || [ -z "$result" ]; then
+#         echo "na"
+#     else
+#         printf "%.2f" "$result"
+#     fi
+# }
+
 find_file() {
     local subtask="$1"
     local seqlen="$2"
-    
+
+    # Prefer the exact (legacy) filename when present.
     if [ -f "$DIR/ruler_${subtask}_${seqlen}.json" ]; then
         echo "$DIR/ruler_${subtask}_${seqlen}.json"
-    elif [ -f "$DIR/vllm_ruler_${subtask}_${seqlen}.json" ]; then
-        echo "$DIR/vllm_ruler_${subtask}_${seqlen}.json"
-    else
-        echo ""
+        return
     fi
+    if [ -f "$DIR/vllm_ruler_${subtask}_${seqlen}.json" ]; then
+        echo "$DIR/vllm_ruler_${subtask}_${seqlen}.json"
+        return
+    fi
+
+    # Newer runners may append an ISO-like timestamp before the .json extension, e.g.
+    # vllm_ruler_<subtask>_<seqlen>_2026-02-09T20-05-08.715047.json
+    # Accept any extra suffix after the seqlen, and pick the newest match if multiple exist.
+    local candidates=()
+
+    # Match both underscore- and dash-separated suffix variants after <seqlen>.
+    while IFS= read -r -d '' f; do candidates+=("$f"); done < <(find "$DIR" -maxdepth 1 -type f -name "ruler_${subtask}_${seqlen}_*.json" -print0 2>/dev/null)
+    while IFS= read -r -d '' f; do candidates+=("$f"); done < <(find "$DIR" -maxdepth 1 -type f -name "ruler_${subtask}_${seqlen}-*.json" -print0 2>/dev/null)
+    while IFS= read -r -d '' f; do candidates+=("$f"); done < <(find "$DIR" -maxdepth 1 -type f -name "vllm_ruler_${subtask}_${seqlen}_*.json" -print0 2>/dev/null)
+    while IFS= read -r -d '' f; do candidates+=("$f"); done < <(find "$DIR" -maxdepth 1 -type f -name "vllm_ruler_${subtask}_${seqlen}-*.json" -print0 2>/dev/null)
+
+    if [ ${#candidates[@]} -eq 0 ]; then
+        echo ""
+        return
+    fi
+
+    # Print most recently modified file.
+    ls -1t "${candidates[@]}" 2>/dev/null | head -n 1
 }
+
+# Function to find the file (check both regular and vllm prefix)
+# find_file() {
+#     local subtask="$1"
+#     local seqlen="$2"
+    
+#     if [ -f "$DIR/ruler_${subtask}_${seqlen}.json" ]; then
+#         echo "$DIR/ruler_${subtask}_${seqlen}.json"
+#     elif [ -f "$DIR/vllm_ruler_${subtask}_${seqlen}.json" ]; then
+#         echo "$DIR/vllm_ruler_${subtask}_${seqlen}.json"
+#     else
+#         echo ""
+#     fi
+# }
 
 # Print header
 echo "=========================================="

--- a/summary_ruler.sh
+++ b/summary_ruler.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+# Script to summarize RULER long context evaluation results across different sequence lengths
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <DIR>"
+    echo ""
+    echo "Example: $0 results/my-model"
+    echo ""
+    echo "This script summarizes RULER long context evaluation results."
+    echo "It looks for files matching: ruler_<subtask>_<seqlen>.json or vllm_ruler_<subtask>_<seqlen>.json"
+    exit 1
+fi
+
+DIR=$1
+
+# RULER subtasks
+NIAH_SINGLE=("niah_single_1" "niah_single_2" "niah_single_3")
+NIAH_MULTI=("niah_multikey_1" "niah_multikey_2" "niah_multikey_3" "niah_multivalue" "niah_multiquery")
+OTHER_TASKS=("ruler_vt" "ruler_cwe" "ruler_fwe" "ruler_qa_hotpot" "ruler_qa_squad")
+ALL_SUBTASKS=("${NIAH_SINGLE[@]}" "${NIAH_MULTI[@]}" "${OTHER_TASKS[@]}")
+
+# Sequence lengths (powers of 2 from 4K to 128K)
+SEQ_LENGTHS=(4096 8192 16384 32768 65536 131072)
+SEQ_LABELS=("4K" "8K" "16K" "32K" "64K" "128K")
+
+# Function to get result from a file
+# Args: filename, metric_key
+get_result() {
+    local file="$1"
+    local subtask="$2"
+    
+    if [ ! -f "$file" ]; then
+        echo "na"
+        return
+    fi
+    
+    # Try different possible metric keys based on task type
+    # First try the main result key with acc,none or exact_match,none
+    local result=$(cat "$file" | jq -r "
+        if .results[\"$subtask\"][\"acc,none\"] then 
+            .results[\"$subtask\"][\"acc,none\"] * 100
+        elif .results[\"$subtask\"][\"exact_match,none\"] then 
+            .results[\"$subtask\"][\"exact_match,none\"] * 100
+        elif .results[\"$subtask\"].acc then 
+            .results[\"$subtask\"].acc * 100
+        elif .results[\"$subtask\"].exact_match then 
+            .results[\"$subtask\"].exact_match * 100
+        else 
+            \"na\" 
+        end
+    " 2>/dev/null)
+    
+    if [ "$result" == "null" ] || [ "$result" == "na" ] || [ -z "$result" ]; then
+        echo "na"
+    else
+        printf "%.2f" "$result"
+    fi
+}
+
+# Function to find the file (check both regular and vllm prefix)
+find_file() {
+    local subtask="$1"
+    local seqlen="$2"
+    
+    if [ -f "$DIR/ruler_${subtask}_${seqlen}.json" ]; then
+        echo "$DIR/ruler_${subtask}_${seqlen}.json"
+    elif [ -f "$DIR/vllm_ruler_${subtask}_${seqlen}.json" ]; then
+        echo "$DIR/vllm_ruler_${subtask}_${seqlen}.json"
+    else
+        echo ""
+    fi
+}
+
+# Print header
+echo "=========================================="
+echo "RULER Long Context Evaluation Summary"
+echo "=========================================="
+echo ""
+
+# Check if any RULER files exist
+found_any=false
+for subtask in "${ALL_SUBTASKS[@]}"; do
+    for seqlen in "${SEQ_LENGTHS[@]}"; do
+        file=$(find_file "$subtask" "$seqlen")
+        if [ -n "$file" ]; then
+            found_any=true
+            break 2
+        fi
+    done
+done
+
+if [ "$found_any" = false ]; then
+    echo "No RULER results found in $DIR"
+    echo ""
+    echo "Expected files: ruler_<subtask>_<seqlen>.json or vllm_ruler_<subtask>_<seqlen>.json"
+    echo "Example: ruler_niah_single_1_4096.json"
+    exit 0
+fi
+
+# Print results by category
+echo "NIAH Single Needle Tasks:"
+echo "------------------------"
+for subtask in "${NIAH_SINGLE[@]}"; do
+    printf "%-20s" "$subtask:"
+    for i in "${!SEQ_LENGTHS[@]}"; do
+        seqlen="${SEQ_LENGTHS[$i]}"
+        file=$(find_file "$subtask" "$seqlen")
+        result=$(get_result "$file" "$subtask")
+        printf "%8s" "$result"
+    done
+    echo ""
+done
+
+echo ""
+echo "NIAH Multi-Key/Value/Query Tasks:"
+echo "---------------------------------"
+for subtask in "${NIAH_MULTI[@]}"; do
+    printf "%-20s" "$subtask:"
+    for i in "${!SEQ_LENGTHS[@]}"; do
+        seqlen="${SEQ_LENGTHS[$i]}"
+        file=$(find_file "$subtask" "$seqlen")
+        result=$(get_result "$file" "$subtask")
+        printf "%8s" "$result"
+    done
+    echo ""
+done
+
+echo ""
+echo "Other RULER Tasks (VT, CWE, FWE, QA):"
+echo "-------------------------------------"
+for subtask in "${OTHER_TASKS[@]}"; do
+    printf "%-20s" "$subtask:"
+    for i in "${!SEQ_LENGTHS[@]}"; do
+        seqlen="${SEQ_LENGTHS[$i]}"
+        file=$(find_file "$subtask" "$seqlen")
+        result=$(get_result "$file" "$subtask")
+        printf "%8s" "$result"
+    done
+    echo ""
+done
+
+echo ""
+echo "=========================================="
+echo "Average Scores by Sequence Length:"
+echo "=========================================="
+printf "%-20s" "Sequence Length:"
+for i in "${!SEQ_LABELS[@]}"; do
+    printf "%8s" "${SEQ_LABELS[$i]}"
+done
+echo ""
+printf "%-20s" "Average Score:"
+
+for i in "${!SEQ_LENGTHS[@]}"; do
+    seqlen="${SEQ_LENGTHS[$i]}"
+    
+    # Collect all valid scores for this sequence length
+    scores=()
+    for subtask in "${ALL_SUBTASKS[@]}"; do
+        file=$(find_file "$subtask" "$seqlen")
+        result=$(get_result "$file" "$subtask")
+        if [ "$result" != "na" ]; then
+            scores+=("$result")
+        fi
+    done
+    
+    # Calculate average if we have scores
+    if [ ${#scores[@]} -gt 0 ]; then
+        avg=$(printf '%s\n' "${scores[@]}" | awk '{sum+=$1; count++} END {if (count>0) printf "%.2f", sum/count; else print "na"}')
+        printf "%8s" "$avg"
+    else
+        printf "%8s" "na"
+    fi
+done
+echo ""
+
+echo ""
+echo "=========================================="
+echo "Average Scores by Task Category:"
+echo "=========================================="
+
+# Calculate category averages across all sequence lengths
+for category_name in "NIAH Single" "NIAH Multi" "Other Tasks" "Overall"; do
+    printf "%-20s" "$category_name:"
+    
+    case "$category_name" in
+        "NIAH Single")
+            tasks=("${NIAH_SINGLE[@]}")
+            ;;
+        "NIAH Multi")
+            tasks=("${NIAH_MULTI[@]}")
+            ;;
+        "Other Tasks")
+            tasks=("${OTHER_TASKS[@]}")
+            ;;
+        "Overall")
+            tasks=("${ALL_SUBTASKS[@]}")
+            ;;
+    esac
+    
+    for i in "${!SEQ_LENGTHS[@]}"; do
+        seqlen="${SEQ_LENGTHS[$i]}"
+        
+        scores=()
+        for subtask in "${tasks[@]}"; do
+            file=$(find_file "$subtask" "$seqlen")
+            result=$(get_result "$file" "$subtask")
+            if [ "$result" != "na" ]; then
+                scores+=("$result")
+            fi
+        done
+        
+        if [ ${#scores[@]} -gt 0 ]; then
+            avg=$(printf '%s\n' "${scores[@]}" | awk '{sum+=$1; count++} END {if (count>0) printf "%.2f", sum/count; else print "na"}')
+            printf "%8s" "$avg"
+        else
+            printf "%8s" "na"
+        fi
+    done
+    echo ""
+done
+
+echo ""
+

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -109,7 +109,7 @@ rm -rf /tmp/pip-packages /tmp/lm-eval
 PIP_TARGET=/tmp/pip-packages
 mkdir -p "$PIP_TARGET"
 echo "Installing transformers {{ env_vars.TRANSFORMERS_VERSION }}..."
-$PYTHON_BIN -m pip install -q --target="$PIP_TARGET" "numpy<2.3" "transformers=={{ env_vars.TRANSFORMERS_VERSION }}"
+$PYTHON_BIN -m pip install -q --target="$PIP_TARGET" "numpy<2.3" "transformers=={{ env_vars.TRANSFORMERS_VERSION }}" "hf_transfer"
 export PYTHONPATH="$PIP_TARGET:${PYTHONPATH:-}"
 
 # Install RULER dependencies if running RULER tasks

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -85,11 +85,18 @@ if [[ "$MODEL_ID" == /* ]] || [[ "$MODEL_ID" == ./* ]]; then
         # Path is under the bind-mounted project directory
         MODEL_LOCAL="/project${MODEL_ID#$HOST_PROJECT_PATH}"
         echo "Converted to container path: $MODEL_LOCAL"
-    elif [[ "$MODEL_ID" == /pfs/lustrep*/scratch/{{ slurm_config.account }}* ]]; then
-        # Alternative PFS path format
-        MODEL_LOCAL="${MODEL_ID#/pfs/lustrep*/scratch/{{ slurm_config.account }}}"
-        MODEL_LOCAL="/project${MODEL_LOCAL}"
-        echo "Converted PFS path to container path: $MODEL_LOCAL"
+    elif [[ "$MODEL_ID" == /pfs/lustrep* ]]; then
+        # Alternative PFS path format - try to extract relative path
+        # Pattern: /pfs/lustrepN/scratch/{{ slurm_config.account }}/rest/of/path
+        # We want: /project/rest/of/path
+        TEMP_PATH="${MODEL_ID#/pfs/lustrep?/scratch/{{ slurm_config.account }}}"
+        if [[ "$TEMP_PATH" != "$MODEL_ID" ]]; then
+            MODEL_LOCAL="/project${TEMP_PATH}"
+            echo "Converted PFS path to container path: $MODEL_LOCAL"
+        else
+            echo "WARNING: Could not convert PFS path"
+            MODEL_LOCAL="$MODEL_ID"
+        fi
     else
         # Path is not in the bind mount - this might fail
         echo "WARNING: Model path is not under /scratch/{{ slurm_config.account }}"

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -356,8 +356,6 @@ MODEL_ARGS="${BASE_ARGS},${DEFAULT_ARGS},{{ env_vars.MODEL_ARGS }}"
 MODEL_ARGS="${BASE_ARGS},${DEFAULT_ARGS}"
 {% endif %}
 {% endif %}
-MODEL_BACKEND="vllm"
-MODEL_ARGS="pretrained=${MODEL_LOCAL:-${MODEL_ID}},dtype=auto,download_dir=/project/hf_cache/models,tensor_parallel_size=${TP},max_model_len=4096,gpu_memory_utilization=0.90"
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${MODEL_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% endif %}

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -83,15 +83,12 @@ if [[ "$MODEL_ID" == /* ]] || [[ "$MODEL_ID" == ./* ]]; then
     
     if [[ "$MODEL_ID" == "$HOST_PROJECT_PATH"* ]]; then
         # Path is under the bind-mounted project directory
-        MODEL_LOCAL="/project${MODEL_ID#$HOST_PROJECT_PATH}"
+        MODEL_LOCAL="${MODEL_ID/$HOST_PROJECT_PATH/\/project}"
         echo "Converted to container path: $MODEL_LOCAL"
     elif [[ "$MODEL_ID" == /pfs/lustrep* ]]; then
-        # Alternative PFS path format - try to extract relative path
-        # Pattern: /pfs/lustrepN/scratch/{{ slurm_config.account }}/rest/of/path
-        # We want: /project/rest/of/path
-        TEMP_PATH="${MODEL_ID#/pfs/lustrep?/scratch/{{ slurm_config.account }}}"
-        if [[ "$TEMP_PATH" != "$MODEL_ID" ]]; then
-            MODEL_LOCAL="/project${TEMP_PATH}"
+        # Alternative PFS path format - use sed for more complex pattern matching
+        MODEL_LOCAL=$(echo "$MODEL_ID" | sed "s|/pfs/lustrep[0-9]/scratch/{{ slurm_config.account }}|/project|")
+        if [[ "$MODEL_LOCAL" != "$MODEL_ID" ]]; then
             echo "Converted PFS path to container path: $MODEL_LOCAL"
         else
             echo "WARNING: Could not convert PFS path"

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -86,13 +86,27 @@ if [[ "$MODEL_ID" == /* ]] || [[ "$MODEL_ID" == ./* ]]; then
         MODEL_LOCAL="${MODEL_ID/$HOST_PROJECT_PATH/\/project}"
         echo "Converted to container path: $MODEL_LOCAL"
     elif [[ "$MODEL_ID" == /pfs/lustrep* ]]; then
-        # Alternative PFS path format - use sed for more complex pattern matching
-        MODEL_LOCAL=$(echo "$MODEL_ID" | sed "s|/pfs/lustrep[0-9]/scratch/{{ slurm_config.account }}|/project|")
-        if [[ "$MODEL_LOCAL" != "$MODEL_ID" ]]; then
+        # Alternative PFS path format
+        # Try multiple lustre versions: lustrep2, lustrep3, lustrep4
+        PFS_PROJECT="/pfs/lustrep2/scratch/{{ slurm_config.account }}"
+        if [[ "$MODEL_ID" == "$PFS_PROJECT"* ]]; then
+            MODEL_LOCAL="${MODEL_ID/$PFS_PROJECT/\/project}"
             echo "Converted PFS path to container path: $MODEL_LOCAL"
         else
-            echo "WARNING: Could not convert PFS path"
-            MODEL_LOCAL="$MODEL_ID"
+            PFS_PROJECT="/pfs/lustrep3/scratch/{{ slurm_config.account }}"
+            if [[ "$MODEL_ID" == "$PFS_PROJECT"* ]]; then
+                MODEL_LOCAL="${MODEL_ID/$PFS_PROJECT/\/project}"
+                echo "Converted PFS path to container path: $MODEL_LOCAL"
+            else
+                PFS_PROJECT="/pfs/lustrep4/scratch/{{ slurm_config.account }}"
+                if [[ "$MODEL_ID" == "$PFS_PROJECT"* ]]; then
+                    MODEL_LOCAL="${MODEL_ID/$PFS_PROJECT/\/project}"
+                    echo "Converted PFS path to container path: $MODEL_LOCAL"
+                else
+                    echo "WARNING: Could not convert PFS path"
+                    MODEL_LOCAL="$MODEL_ID"
+                fi
+            fi
         fi
     else
         # Path is not in the bind mount - this might fail

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -34,22 +34,47 @@ else
     GPUS=4
 fi
 
+# Auto-detect alt scratch root from MODEL_ID if it’s a local path
+ALT_PROJECT=""
+if [[ "{{ env_vars.MODEL }}" == /scratch/* ]]; then
+  MODEL_PATH="{{ env_vars.MODEL }}"
+  # Primary root
+  PRIMARY_ROOT="$PRJ"
+  # If model is under /scratch/project_* but not under PRIMARY_ROOT, capture that root
+  if [[ "$MODEL_PATH" == /* ]]; then
+    # Extract "/scratch/project_<id>" prefix
+    ALT_CAND="/scratch/$(echo "$MODEL_PATH" | awk -F'/' '{print $3}')"
+    # ALT_CAND is "project_<id>"; build full root "/scratch/project_<id>"
+    ALT_PROJECT="$ALT_CAND"
+    # If ALT_PROJECT equals PRIMARY_ROOT, ignore
+    if [[ "$ALT_PROJECT" == "$PRIMARY_ROOT" ]]; then
+      ALT_PROJECT=""
+    else
+      echo "Detected alternative project root for model path: $ALT_PROJECT"
+      ALT_PROJECT="--bind $ALT_CAND"
+    fi
+  fi
+fi
+
+
 # topology & model knobs
 export N_NODES=1
 export TP="$GPUS"
 export MODEL_ID="{{ env_vars.MODEL }}"
-
+#export SINGULARITY_BIND=/scratch,/flash 
 {% if env_vars.LM_EVAL_PATH %}
 # Bind mount local lm-eval path into container
 BIND_LM_EVAL="--bind {{ env_vars.LM_EVAL_PATH }}:/workspace/lm-eval-host"
 {% else %}
 BIND_LM_EVAL=""
 {% endif %}
+#--cleanenv
 
 srun -A "$ACC" -p "{{ slurm_config.partition }}" -N "$N_NODES" -n1 -t "{{ slurm_config.time }}" --gpus-per-task="$GPUS" \
-  singularity exec --rocm --cleanenv \
+  singularity exec --rocm \
     --bind "$SCR":/workspace \
     --bind "$PRJ":/project \
+    $ALT_PROJECT \
     --bind /usr/share/libdrm:/usr/share/libdrm \
     $BIND_LM_EVAL \
     --env SLURM_JOB_ID="$SLURM_JOB_ID" \
@@ -360,7 +385,8 @@ MODEL_BACKEND="dummy"
 MODEL_ARGS="pretrained={{ env_vars.MODEL }}"
 {% else %}
 MODEL_BACKEND="hf-auto"
-BASE_ARGS="pretrained=${MODEL_LOCAL:-${MODEL_ID}},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
+#BASE_ARGS="pretrained=${MODEL_LOCAL:-${MODEL_ID}},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
+BASE_ARGS="pretrained=${MODEL_LOCAL:-${MODEL_ID}},device_map=auto,dtype=auto,trust_remote_code=True,attn_implementation=sdpa"
 
 {% if env_vars.MAX_SEQ_LENGTH %}
 # RULER task: Force max_length to match RULER sequence length
@@ -387,7 +413,8 @@ MODEL_ARGS="${BASE_ARGS}"
 {% endif %}
 {% endif %}
 {% endif %}
-
+echo "Using model backend: $MODEL_BACKEND"
+echo "Model args: $MODEL_ARGS"
 # Run eval
 BATCH_SIZE="{% if env_vars.BATCH_SIZE %}{{ env_vars.BATCH_SIZE }}{% elif env_vars.BACKEND == "vllm" %}auto{% else %}4{% endif %}"
 

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -72,6 +72,9 @@ TP="${TP:-4}"
 MODEL_SAFE="${MODEL_ID//\//-}"
 PREFETCH_LOCAL_DIR="/project/hf_cache/models/${MODEL_SAFE}"
 
+# Initialize flag (needed for set -u)
+IS_LOCAL_MODEL=false
+
 # Detect if MODEL_ID is a local path or a HuggingFace repo
 if [[ "$MODEL_ID" == /* ]] || [[ "$MODEL_ID" == ./* ]]; then
     # Local path - convert to container path if needed

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -385,7 +385,7 @@ BASE_ARGS="pretrained=${MODEL_LOCAL},dtype=auto,download_dir=/project/hf_cache/m
 {% if env_vars.MODEL_ARGS %}
 EXTRA_ARGS="{{ env_vars.MODEL_ARGS }}"
 # Remove any max_model_len setting from extra args
-EXTRA_ARGS=$(echo "$EXTRA_ARGS" | sed 's/max_model_len=[0-9]*,\?//g' | sed 's/,,/,/g' | sed 's/^,//;s/,$//')
+EXTRA_ARGS=$(echo "$EXTRA_ARGS" | sed "s/max_model_len=[0-9]*,\?//g" | sed "s/,,/,/g" | sed "s/^,//;s/,\$//")
 {% else %}
 EXTRA_ARGS=""
 {% endif %}
@@ -421,7 +421,7 @@ BASE_ARGS="pretrained=${MODEL_LOCAL},device_map=auto,dtype=bfloat16,trust_remote
 {% if env_vars.MODEL_ARGS %}
 EXTRA_ARGS="{{ env_vars.MODEL_ARGS }}"
 # Remove any max_length setting from extra args
-EXTRA_ARGS=$(echo "$EXTRA_ARGS" | sed 's/max_length=[0-9]*,\?//g' | sed 's/,,/,/g' | sed 's/^,//;s/,$//')
+EXTRA_ARGS=$(echo "$EXTRA_ARGS" | sed "s/max_length=[0-9]*,\?//g" | sed "s/,,/,/g" | sed "s/^,//;s/,\$//")
 {% else %}
 EXTRA_ARGS=""
 {% endif %}

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -318,41 +318,47 @@ if [[ -z "$CONTAINER_OUTPUT_FILE" ]]; then
   echo "ERROR: OUTPUT_FILE is empty. Check main.py env_vars." >&2
   exit 2
 fi
-USER_SCRATCH_DIR="/scratch/project_462000353/$USER"
-PFS_USER_PREFIX="/pfs/lustrep2/scratch/project_462000353/$USER/"
 
 echo "DEBUG: Original OUTPUT_FILE: $CONTAINER_OUTPUT_FILE"
 echo "DEBUG: SCR inside container: $SCR"
 
-# Convert various host path patterns to container paths
+# The bind mount is: /scratch/{{ slurm_config.account }} -> /project in container
+HOST_PROJECT_PATH="/scratch/{{ slurm_config.account }}"
+
+# Convert output file path from host to container
 if [[ "$CONTAINER_OUTPUT_FILE" == "$SCR"* ]]; then
-    echo "DEBUG: Path matches SCR prefix, converting..."
-    # Path relative to current working directory - remove SCR prefix and add /workspace
+    echo "DEBUG: Path matches SCR (workspace) prefix, converting..."
+    # Path relative to current working directory - already in workspace
     RELATIVE_PATH="${CONTAINER_OUTPUT_FILE#$SCR}"
-    # Remove leading slash if present
     RELATIVE_PATH="${RELATIVE_PATH#/}"
     CONTAINER_OUTPUT_FILE="/workspace/${RELATIVE_PATH}"
     echo "DEBUG: Converted to: $CONTAINER_OUTPUT_FILE"
-elif [[ "$CONTAINER_OUTPUT_FILE" == "$PFS_USER_PREFIX"* ]]; then
-    echo "DEBUG: Path matches PFS prefix, converting..."
-    # /pfs paths under user directory
-    RELATIVE_PATH="${CONTAINER_OUTPUT_FILE#$PFS_USER_PREFIX}"
-    RELATIVE_PATH="${RELATIVE_PATH#evals/}"
-    CONTAINER_OUTPUT_FILE="/workspace/${RELATIVE_PATH}"
+elif [[ "$CONTAINER_OUTPUT_FILE" == "$HOST_PROJECT_PATH"* ]]; then
+    echo "DEBUG: Path matches project path, converting..."
+    # Path is under /scratch/project_XXXXX on host -> /project in container
+    RELATIVE_PATH="${CONTAINER_OUTPUT_FILE#$HOST_PROJECT_PATH}"
+    CONTAINER_OUTPUT_FILE="/project${RELATIVE_PATH}"
     echo "DEBUG: Converted to: $CONTAINER_OUTPUT_FILE"
-elif [[ "$CONTAINER_OUTPUT_FILE" == "$USER_SCRATCH_DIR"* ]]; then
-    echo "DEBUG: Path matches USER_SCRATCH_DIR prefix, converting..."
-    # Direct /scratch paths under user directory
-    RELATIVE_PATH="${CONTAINER_OUTPUT_FILE#$USER_SCRATCH_DIR}"
-    # Remove leading slash if present
-    RELATIVE_PATH="${RELATIVE_PATH#/}"
-    CONTAINER_OUTPUT_FILE="/workspace/${RELATIVE_PATH}"
-    echo "DEBUG: Converted to: $CONTAINER_OUTPUT_FILE"
+elif [[ "$CONTAINER_OUTPUT_FILE" == /pfs/lustrep* ]]; then
+    echo "DEBUG: Path is PFS path, converting..."
+    # PFS paths like /pfs/lustrepN/scratch/project_XXXXX/... -> /project/...
+    # Try each lustre version
+    for LUSTREP in lustrep2 lustrep3 lustrep4; do
+        PFS_PATH="/pfs/${LUSTREP}/scratch/{{ slurm_config.account }}"
+        if [[ "$CONTAINER_OUTPUT_FILE" == "$PFS_PATH"* ]]; then
+            RELATIVE_PATH="${CONTAINER_OUTPUT_FILE#$PFS_PATH}"
+            CONTAINER_OUTPUT_FILE="/project${RELATIVE_PATH}"
+            echo "DEBUG: Converted PFS path to: $CONTAINER_OUTPUT_FILE"
+            break
+        fi
+    done
 else
-    echo "DEBUG: No path conversion matched - keeping original path"
+    echo "DEBUG: Path does not match expected patterns - using as-is (might fail)"
+    echo "       If this fails, ensure output path is under /scratch/{{ slurm_config.account }}"
 fi
 
 # Prepare final output directory inside container
+echo "Creating output directory: $(dirname "$CONTAINER_OUTPUT_FILE")"
 mkdir -p "$(dirname "$CONTAINER_OUTPUT_FILE")"
 echo "Final results will be saved to: $CONTAINER_OUTPUT_FILE"
 

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -379,18 +379,31 @@ FEWSHOT_AS_MULTITURN_FLAG=""
 {% if env_vars.BACKEND == "vllm" %}
 BASE_ARGS="pretrained=${MODEL_LOCAL},dtype=auto,download_dir=/project/hf_cache/models,tensor_parallel_size=${TP}"
 
-# Set max_model_len based on RULER sequence length or default
 {% if env_vars.MAX_SEQ_LENGTH %}
-DEFAULT_ARGS="max_model_len={{ env_vars.MAX_SEQ_LENGTH }},gpu_memory_utilization=0.90"
-echo "RULER: Setting max_model_len={{ env_vars.MAX_SEQ_LENGTH }}"
+# RULER task: Force max_model_len to match RULER sequence length
+# Strip any max_model_len from MODEL_ARGS if present, then add RULER length
+{% if env_vars.MODEL_ARGS %}
+EXTRA_ARGS="{{ env_vars.MODEL_ARGS }}"
+# Remove any max_model_len setting from extra args
+EXTRA_ARGS=$(echo "$EXTRA_ARGS" | sed 's/max_model_len=[0-9]*,\?//g' | sed 's/,,/,/g' | sed 's/^,//;s/,$//')
 {% else %}
-DEFAULT_ARGS="max_model_len=4096,gpu_memory_utilization=0.90"
+EXTRA_ARGS=""
 {% endif %}
-
+# Add RULER max_model_len (must match sequence length for RULER)
+if [ -n "$EXTRA_ARGS" ]; then
+    MODEL_ARGS="${BASE_ARGS},${EXTRA_ARGS},max_model_len={{ env_vars.MAX_SEQ_LENGTH }},gpu_memory_utilization=0.90"
+else
+    MODEL_ARGS="${BASE_ARGS},max_model_len={{ env_vars.MAX_SEQ_LENGTH }},gpu_memory_utilization=0.90"
+fi
+echo "RULER: Using max_model_len={{ env_vars.MAX_SEQ_LENGTH }} (matching RULER sequence length)"
+{% else %}
+# Non-RULER task: Use default or provided max_model_len
+DEFAULT_ARGS="max_model_len=4096,gpu_memory_utilization=0.90"
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${BASE_ARGS},${DEFAULT_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% else %}
 MODEL_ARGS="${BASE_ARGS},${DEFAULT_ARGS}"
+{% endif %}
 {% endif %}
 
 MODEL_BACKEND="vllm"
@@ -402,16 +415,29 @@ echo "Using dummy backend (cache-only, no model weights loaded)"
 {% else %}
 BASE_ARGS="pretrained=${MODEL_LOCAL},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
 
-# Add max_length for RULER tasks
 {% if env_vars.MAX_SEQ_LENGTH %}
-BASE_ARGS="${BASE_ARGS},max_length={{ env_vars.MAX_SEQ_LENGTH }}"
-echo "RULER: Setting max_length={{ env_vars.MAX_SEQ_LENGTH }}"
+# RULER task: Force max_length to match RULER sequence length
+# Strip any max_length from MODEL_ARGS if present, then add RULER length
+{% if env_vars.MODEL_ARGS %}
+EXTRA_ARGS="{{ env_vars.MODEL_ARGS }}"
+# Remove any max_length setting from extra args
+EXTRA_ARGS=$(echo "$EXTRA_ARGS" | sed 's/max_length=[0-9]*,\?//g' | sed 's/,,/,/g' | sed 's/^,//;s/,$//')
+{% else %}
+EXTRA_ARGS=""
 {% endif %}
-
+if [ -n "$EXTRA_ARGS" ]; then
+    MODEL_ARGS="${BASE_ARGS},${EXTRA_ARGS},max_length={{ env_vars.MAX_SEQ_LENGTH }}"
+else
+    MODEL_ARGS="${BASE_ARGS},max_length={{ env_vars.MAX_SEQ_LENGTH }}"
+fi
+echo "RULER: Using max_length={{ env_vars.MAX_SEQ_LENGTH }} (matching RULER sequence length)"
+{% else %}
+# Non-RULER task: Use provided or default settings
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${BASE_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% else %}
 MODEL_ARGS="${BASE_ARGS}"
+{% endif %}
 {% endif %}
 
 MODEL_BACKEND="hf-auto"
@@ -428,8 +454,8 @@ BATCH_SIZE="4"
 {% endif %}
 
 {% if env_vars.MAX_SEQ_LENGTH %}
-# Set up metadata for RULER tasks - properly escaped for bash
-TASK_METADATA_FLAG="--metadata {\\\"max_seq_lengths\\\":[{{ env_vars.MAX_SEQ_LENGTH }}]}"
+# Set up metadata for RULER tasks
+TASK_METADATA_FLAG="--metadata {\"max_seq_lengths\":[{{ env_vars.MAX_SEQ_LENGTH }}]}"
 echo "Using RULER metadata for sequence length: {{ env_vars.MAX_SEQ_LENGTH }}"
 {% else %}
 TASK_METADATA_FLAG=""

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -326,7 +326,6 @@ FEWSHOT_AS_MULTITURN_FLAG=""
 {% endif %}
 
 {% if env_vars.BACKEND == "vllm" %}
-# vllm backend MODEL_ARGS logic (resolved merge conflict)
 MODEL_BACKEND="vllm"
 BASE_ARGS="pretrained=${MODEL_LOCAL:-${MODEL_ID}},dtype=auto,download_dir=/project/hf_cache/models,tensor_parallel_size=${TP}"
 
@@ -356,13 +355,11 @@ MODEL_ARGS="${BASE_ARGS},${DEFAULT_ARGS},{{ env_vars.MODEL_ARGS }}"
 MODEL_ARGS="${BASE_ARGS},${DEFAULT_ARGS}"
 {% endif %}
 {% endif %}
-{% if env_vars.MODEL_ARGS %}
-MODEL_ARGS="${MODEL_ARGS},{{ env_vars.MODEL_ARGS }}"
-{% endif %}
 {% elif env_vars.BACKEND == "dummy" %}
 MODEL_BACKEND="dummy"
 MODEL_ARGS="pretrained={{ env_vars.MODEL }}"
 {% else %}
+MODEL_BACKEND="hf-auto"
 BASE_ARGS="pretrained=${MODEL_LOCAL:-${MODEL_ID}},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
 
 {% if env_vars.MAX_SEQ_LENGTH %}
@@ -388,11 +385,6 @@ MODEL_ARGS="${BASE_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% else %}
 MODEL_ARGS="${BASE_ARGS}"
 {% endif %}
-{% endif %}
-MODEL_BACKEND="hf-auto"
-MODEL_ARGS="pretrained=${MODEL_LOCAL:-${MODEL_ID}},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
-{% if env_vars.MODEL_ARGS %}
-MODEL_ARGS="${MODEL_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% endif %}
 {% endif %}
 

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -378,7 +378,14 @@ FEWSHOT_AS_MULTITURN_FLAG=""
 # Backend-specific model configuration
 {% if env_vars.BACKEND == "vllm" %}
 BASE_ARGS="pretrained=${MODEL_LOCAL},dtype=auto,download_dir=/project/hf_cache/models,tensor_parallel_size=${TP}"
+
+# Set max_model_len based on RULER sequence length or default
+{% if env_vars.MAX_SEQ_LENGTH %}
+DEFAULT_ARGS="max_model_len={{ env_vars.MAX_SEQ_LENGTH }},gpu_memory_utilization=0.90"
+echo "RULER: Setting max_model_len={{ env_vars.MAX_SEQ_LENGTH }}"
+{% else %}
 DEFAULT_ARGS="max_model_len=4096,gpu_memory_utilization=0.90"
+{% endif %}
 
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${BASE_ARGS},${DEFAULT_ARGS},{{ env_vars.MODEL_ARGS }}"
@@ -394,6 +401,12 @@ MODEL_ARGS="pretrained={{ env_vars.MODEL }}"
 echo "Using dummy backend (cache-only, no model weights loaded)"
 {% else %}
 BASE_ARGS="pretrained=${MODEL_LOCAL},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
+
+# Add max_length for RULER tasks
+{% if env_vars.MAX_SEQ_LENGTH %}
+BASE_ARGS="${BASE_ARGS},max_length={{ env_vars.MAX_SEQ_LENGTH }}"
+echo "RULER: Setting max_length={{ env_vars.MAX_SEQ_LENGTH }}"
+{% endif %}
 
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${BASE_ARGS},{{ env_vars.MODEL_ARGS }}"
@@ -414,6 +427,14 @@ BATCH_SIZE="auto"
 BATCH_SIZE="4"
 {% endif %}
 
+{% if env_vars.TASK_METADATA %}
+# Set up metadata for RULER tasks
+TASK_METADATA_FLAG="--metadata '{{ env_vars.TASK_METADATA }}'"
+echo "Using task metadata: {{ env_vars.TASK_METADATA }}"
+{% else %}
+TASK_METADATA_FLAG=""
+{% endif %}
+
 python -m lm_eval \
   --model "$MODEL_BACKEND" \
   --model_args "$MODEL_ARGS" \
@@ -423,6 +444,7 @@ python -m lm_eval \
   --output_path "$RANDOM_DIR" \
   $CHAT_TEMPLATE_FLAG \
   $FEWSHOT_AS_MULTITURN_FLAG \
+  $TASK_METADATA_FLAG \
 {% if env_vars.LIMIT %}  --limit {{ env_vars.LIMIT }} \
 {% endif %}  --log_samples \
 {% if env_vars.LM_EVAL_ARGS %}  {{ env_vars.LM_EVAL_ARGS }}

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -251,7 +251,8 @@ python /workspace/tools/sanity.py
 python /workspace/tools/stage_aiter.py
 
 {% if env_vars.BACKEND != "dummy" %}
-# Prefetch model if it's a HuggingFace repo and skip for local models
+# Prefetch model if it is a HuggingFace repo and skip for local models
+
 if [[ "${IS_LOCAL_MODEL:-false}" == "false" ]]; then
     echo "Downloading model from HuggingFace..."
     python /workspace/tools/prefetch.py

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -12,32 +12,39 @@
 #SBATCH --gres={{ slurm_config.gres }}
 #SBATCH --time={{ slurm_config.time }}
 
-# link latest log files
 ln -sf {{ slurm_config.log_dir }}/$SLURM_JOB_ID.out {{ slurm_config.log_dir }}/latest.out
 ln -sf {{ slurm_config.log_dir }}/$SLURM_JOB_ID.err {{ slurm_config.log_dir }}/latest.err
 
 set -euo pipefail
 
-export IMG="/scratch/{{ slurm_config.account }}/containers/vllm_v10.1.1.sif"
-export PRJ="/scratch/{{ slurm_config.account }}"   # will be /project in container
-export SCR="$(pwd -P)"                     # SCR = scratch directory, will be /workspace in container (resolve symlinks)
+echo "Starting lm_eval job..."
+echo "Host: $(hostname)"
+echo "Job ID: $SLURM_JOB_ID"
+
+# LUMI AI Factory container (Ubuntu 24.04, ROCm 6.4, vLLM 0.12)
+export IMG="/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20251209_134408/lumi-multitorch-full-u24r64f21m43t29-20251209_134408.sif"
+# Storage project (use job's account project for storage)
+export STORAGE_PRJ="/scratch/{{ slurm_config.account }}"
+export SCR="$(pwd -P)"
 export ACC="{{ slurm_config.account }}"
 
-# Parse gres for GPU count (e.g., "gpu:mi250:4" -> 4)
+# Parse gres for GPU count
 GRES="{{ slurm_config.gres }}"
 if [[ "$GRES" =~ gpu:[^:]*:([0-9]+) ]]; then
     GPUS="${BASH_REMATCH[1]}"
 elif [[ "$GRES" =~ gpu:([0-9]+) ]]; then
     GPUS="${BASH_REMATCH[1]}"
 else
-    echo "Warning: Could not parse GPU count from GRES '$GRES', defaulting to 4"
-    GPUS=4
+    GPUS=1
 fi
 
-# topology & model knobs
-export N_NODES=1
+export MODEL="{{ env_vars.MODEL }}"
 export TP="$GPUS"
-export MODEL_ID="{{ env_vars.MODEL }}"
+
+echo "Container: $IMG"
+echo "Model: $MODEL"
+echo "GPUs: $GPUS"
+echo "Storage: $STORAGE_PRJ"
 
 {% if env_vars.LM_EVAL_PATH %}
 # Bind mount local lm-eval path into container
@@ -46,164 +53,96 @@ BIND_LM_EVAL="--bind {{ env_vars.LM_EVAL_PATH }}:/workspace/lm-eval-host"
 BIND_LM_EVAL=""
 {% endif %}
 
-srun -A "$ACC" -p "{{ slurm_config.partition }}" -N "$N_NODES" -n1 -t "{{ slurm_config.time }}" --gpus-per-task="$GPUS" \
+# Use srun to properly allocate GPUs to the container
+srun -A "$ACC" -p "{{ slurm_config.partition }}" -N1 -n1 -t "{{ slurm_config.time }}" --gpus-per-task="$GPUS" \
   singularity exec --rocm --cleanenv \
     --bind "$SCR":/workspace \
-    --bind "$PRJ":/project \
+    --bind "$STORAGE_PRJ":/project \
+    --bind /pfs,/scratch,/projappl,/flash,/appl \
+    --bind /var/spool/slurmd \
+    --bind /opt/cray/ \
+    --bind /usr/lib64/libcxi.so.1 \
     --bind /usr/share/libdrm:/usr/share/libdrm \
     $BIND_LM_EVAL \
-    --env SLURM_JOB_ID="$SLURM_JOB_ID" \
-    --env MODEL_ID="$MODEL_ID" \
+    --env MODEL="$MODEL" \
     --env TP="$TP" \
     --env SCR="$SCR" \
     --env USER="$USER" \
+    --env SLURM_JOB_ID="$SLURM_JOB_ID" \
     --env HF_HOME=/project/cache/huggingface \
     --env HUGGINGFACE_HUB_CACHE=/project/cache/huggingface/hub \
-    --env TRANSFORMERS_CACHE=/project/cache/huggingface/models \
-    --env HF_DATASETS_CACHE=/project/cache/huggingface/datasets \
-    --env XDG_CACHE_HOME=/project/cache/huggingface/xdg \
     --env HF_TOKEN="${HF_TOKEN:-}" \
+    --env STORAGE_PRJ="$STORAGE_PRJ" \
     "$IMG" bash -c '
 set -euo pipefail
-umask 002
+echo "Inside container..."
 
-# Force HOME=/tmp so aiter builds ephemerally and disappears with the job
+# Set HOME to /tmp for ephemeral builds
 export HOME=/tmp
 
-PYTHON_BIN="/opt/miniconda3/envs/pytorch/bin/python"
-export PYTHON_BIN
+source /opt/venv/bin/activate
+PYTHON_BIN="/opt/venv/bin/python"
 
-# ---- env & caches (disable xet + telemetry) ----
+echo "Python: $PYTHON_BIN"
+echo "ROCR_VISIBLE_DEVICES: ${ROCR_VISIBLE_DEVICES:-not set}"
+echo "HIP_VISIBLE_DEVICES: ${HIP_VISIBLE_DEVICES:-not set}"
+$PYTHON_BIN -c "import torch; print(f\"PyTorch: {torch.__version__}, CUDA: {torch.cuda.is_available()}, Devices: {torch.cuda.device_count()}\")"
+$PYTHON_BIN -c "import vllm; print(f\"vLLM: {vllm.__version__}\")"
+
 export HF_HUB_DISABLE_XET=1
-export HF_HUB_ENABLE_HF_TRANSFER=0
-export HF_HUB_DISABLE_TELEMETRY=1
-
-export PATH="/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/miniconda3/envs/pytorch/bin:/usr/local/bin:/usr/bin:/bin"
-export TORCH_EXTENSIONS_DIR=/dev/shm/torch_ext
-export TORCHINDUCTOR_CACHE_DIR=/project/cache/huggingface/torchinductor
-export VLLM_COMPILER_CACHE_DIR=/project/cache/huggingface/vllm-compile
-export TRITON_CACHE_DIR=/project/cache/huggingface/triton
+export MIOPEN_USER_DB_PATH=/tmp/${USER}-miopen-cache
+export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_USER_DB_PATH
+export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
+export NCCL_NET_GDR_LEVEL=3
+export PYTORCH_ROCM_ARCH=gfx90a
 
 export VLLM_USE_V1=1
 export VLLM_TARGET_DEVICE=rocm
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export HIP_ARCHITECTURES=gfx90a
 
-# Avoid the 1-GPU trap - ensure PyTorch uses all allocated GPUs
-unset HIP_VISIBLE_DEVICES
+mkdir -p /project/cache/huggingface/hub "$MIOPEN_USER_DB_PATH"
 
-mkdir -p /project/cache/huggingface/{hub,models,datasets,torchinductor,xdg,vllm-compile,triton} \
-         /dev/shm/torch_ext "$HOME/.aiter/jit/build" "$HOME/.aiter/jit/install" \
-         /tmp/tools
+# Clean up any leftover files from previous runs
+rm -rf /tmp/pip-packages /tmp/lm-eval
 
-export CC=/opt/rocm/llvm/bin/clang
-export CXX=/opt/rocm/llvm/bin/clang++
+# Install transformers
+PIP_TARGET=/tmp/pip-packages
+mkdir -p "$PIP_TARGET"
+echo "Installing transformers {{ env_vars.TRANSFORMERS_VERSION }}..."
+$PYTHON_BIN -m pip install -q --target="$PIP_TARGET" "numpy<2.3" "transformers=={{ env_vars.TRANSFORMERS_VERSION }}"
+export PYTHONPATH="$PIP_TARGET:${PYTHONPATH:-}"
 
-# Make sure ninja is available
-${PYTHON_BIN} -m pip -q install --user -U ninja || true
-
-# ------- write helper: stage_aiter.py (NO stdin execution) -------
-cat > /tmp/tools/stage_aiter.py <<PY
-import os, glob, shutil, importlib, pathlib, subprocess, sys
-
-home = os.path.expanduser("~")
-jit_root   = os.path.join(home, ".aiter", "jit")
-build_root = os.path.join(jit_root, "build")
-inst_root  = os.path.join(jit_root, "install")
-pkg_root   = os.path.join(inst_root, "private_aiter")
-pkg_jit    = os.path.join(pkg_root, "jit")
-
-os.makedirs(pkg_jit, exist_ok=True)
-pathlib.Path(os.path.join(pkg_root, "__init__.py")).write_text("")
-pathlib.Path(os.path.join(pkg_jit, "__init__.py")).write_text("")
-
-# trigger a build once (ok if it raises)
-try:
-    import aiter
-    from aiter.ops import enum  # will build module_aiter_enum
-except Exception as e:
-    print("[aiter] prewarm raised:", repr(e))
-
-hits = glob.glob(os.path.join(build_root, "**", "module_aiter_enum*.so"), recursive=True)
-if not hits:
-    raise SystemExit("[stage] no compiled module_aiter_enum*.so found under " + build_root)
-
-so_src = max(hits, key=os.path.getmtime)
-dst = os.path.join(pkg_jit, "module_aiter_enum.so")
-if os.path.islink(dst) or os.path.exists(dst):
-    os.remove(dst)
-try:
-    os.symlink(so_src, dst)
-    print("[stage] symlinked", dst, "->", so_src)
-except OSError:
-    shutil.copy2(so_src, dst)
-    print("[stage] copied", so_src, "->", dst)
-
-print("[ldd]")
-print(subprocess.check_output(["ldd", dst], text=True))
-
-sys.path.insert(0, inst_root)
-m = importlib.import_module("private_aiter.jit.module_aiter_enum")
-print("[stage] import OK:", m.__spec__.origin)
-
-import aiter; from aiter.ops import enum as _e
-print("[stage] aiter import OK")
-PY
-
-# Stage aiter
-${PYTHON_BIN} /tmp/tools/stage_aiter.py
-
-export PYTHONPATH="$HOME/.aiter/jit/install:${PYTHONPATH-}"
-
-# Install specific transformers version
-${PYTHON_BIN} -m pip install --user -q -U transformers=={{ env_vars.TRANSFORMERS_VERSION }}
-
-# ------- get LUMI harness (puts it first on sys.path) -------
 EVAL_HARNESS_DIR="/tmp/lm-eval"
-
-# Function to setup lm-evaluation-harness (no locking needed with job-specific dirs)
-setup_lm_eval() {
-    echo "Setting up lm-evaluation-harness in $EVAL_HARNESS_DIR"
+echo "Setting up lm-evaluation-harness in $EVAL_HARNESS_DIR"
 
 {% if env_vars.LM_EVAL_PATH %}
-    # Use local path - copy from bind-mounted location
-    echo "Using local lm-evaluation-harness from: {{ env_vars.LM_EVAL_PATH }}"
-    cp -r "/workspace/lm-eval-host" "$EVAL_HARNESS_DIR"
+echo "Using local lm-evaluation-harness from: {{ env_vars.LM_EVAL_PATH }}"
+cp -r "/workspace/lm-eval-host" "$EVAL_HARNESS_DIR"
 {% else %}
-    # Use git repository
-    REPO_URL="{{ env_vars.LM_EVAL_REPO }}"
-    REPO_REF="{{ env_vars.LM_EVAL_REF }}"
-
-    echo "Cloning lm-evaluation-harness from $REPO_URL (ref: $REPO_REF)..."
-    git clone --depth 1 -b "$REPO_REF" "$REPO_URL" "$EVAL_HARNESS_DIR"
+REPO_URL="{{ env_vars.LM_EVAL_REPO }}"
+REPO_REF="{{ env_vars.LM_EVAL_REF }}"
+echo "Cloning lm-evaluation-harness from $REPO_URL (ref: $REPO_REF)..."
+git clone --depth 1 -b "$REPO_REF" "$REPO_URL" "$EVAL_HARNESS_DIR"
 {% endif %}
-}
 
-# Setup lm-evaluation-harness
-setup_lm_eval
-export PYTHONPATH="$EVAL_HARNESS_DIR:${PYTHONPATH-}"
+export PYTHONPATH="$EVAL_HARNESS_DIR:${PYTHONPATH:-}"
 
-# Create a temporary directory for lm_eval output
-RANDOM_DIR="/tmp/lm_eval_$(date +%s%N)"
-mkdir -p "$RANDOM_DIR"
-
+# Remap output file path from host to container if needed
 OUTPUT_FILE="{{ env_vars.OUTPUT_FILE }}"
 if [[ "$OUTPUT_FILE" == "$SCR"* ]]; then
-  # map host path under $SCR to the /workspace bind mount
   OUTPUT_FILE="/workspace${OUTPUT_FILE#$SCR}"
 elif [[ "$OUTPUT_FILE" != /* ]]; then
   OUTPUT_FILE="/workspace/$OUTPUT_FILE"
 fi
 mkdir -p "$(dirname "$OUTPUT_FILE")"
 
-# Remap MODEL_ID from host paths to container paths if needed
-if [[ "$MODEL_ID" == /scratch/{{ slurm_config.account }}/* ]]; then
-  MODEL_ID="/project${MODEL_ID#/scratch/{{ slurm_config.account }}}"
-elif [[ "$MODEL_ID" == "$SCR"/* ]]; then
-  MODEL_ID="/workspace${MODEL_ID#$SCR}"
+# Remap MODEL from host paths to container paths if needed
+if [[ "$MODEL" == "$STORAGE_PRJ"/* ]]; then
+  MODEL="/project${MODEL#$STORAGE_PRJ}"
+elif [[ "$MODEL" == "$SCR"/* ]]; then
+  MODEL="/workspace${MODEL#$SCR}"
 fi
 
-# Set up chat template flags
 {% if env_vars.APPLY_CHAT_TEMPLATE %}
 CHAT_TEMPLATE_FLAG="--apply_chat_template"
 {% else %}
@@ -218,31 +157,31 @@ FEWSHOT_AS_MULTITURN_FLAG=""
 
 {% if env_vars.BACKEND == "vllm" %}
 MODEL_BACKEND="vllm"
-MODEL_ARGS="pretrained=${MODEL_ID},dtype=auto,download_dir=/project/cache/huggingface/models,tensor_parallel_size=${TP},max_model_len=4096,gpu_memory_utilization=0.90"
+MODEL_ARGS="pretrained=${MODEL},dtype=auto,tensor_parallel_size=${TP},gpu_memory_utilization=0.90"
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${MODEL_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% endif %}
 {% elif env_vars.BACKEND == "dummy" %}
 MODEL_BACKEND="dummy"
-MODEL_ARGS="pretrained={{ env_vars.MODEL }}"
+MODEL_ARGS="pretrained=${MODEL}"
 {% else %}
 MODEL_BACKEND="hf-auto"
-MODEL_ARGS="pretrained=${MODEL_ID},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
+MODEL_ARGS="pretrained=${MODEL},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${MODEL_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% endif %}
 {% endif %}
 
-# Run eval
 BATCH_SIZE="{% if env_vars.BATCH_SIZE %}{{ env_vars.BATCH_SIZE }}{% elif env_vars.BACKEND == "vllm" %}auto{% else %}4{% endif %}"
 
-${PYTHON_BIN} -m lm_eval \
+echo "Running lm_eval with model: $MODEL"
+$PYTHON_BIN -m lm_eval \
   --model "$MODEL_BACKEND" \
   --model_args "$MODEL_ARGS" \
   --tasks "{{ env_vars.TASK_LIST }}" \
   --num_fewshot {{ env_vars.NUM_FEWSHOT }} \
   --batch_size "$BATCH_SIZE" \
-  --output_path "$RANDOM_DIR" \
+  --output_path "$OUTPUT_FILE" \
   $CHAT_TEMPLATE_FLAG \
   $FEWSHOT_AS_MULTITURN_FLAG \
 {% if env_vars.LIMIT %}  --limit {{ env_vars.LIMIT }} \
@@ -250,6 +189,7 @@ ${PYTHON_BIN} -m lm_eval \
 {% if env_vars.LM_EVAL_ARGS %}  {{ env_vars.LM_EVAL_ARGS }}
 {% endif %}
 
-find "$RANDOM_DIR" -name "results_*.json" -exec mv {} "$OUTPUT_FILE" \;
-rm -rf "$RANDOM_DIR"
+echo "lm_eval completed!"
 '
+
+echo "Job finished"

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -306,6 +306,13 @@ setup_lm_eval() {
 setup_lm_eval
 export PYTHONPATH="$EVAL_HARNESS_DIR:$PYTHONPATH"
 
+# Install RULER dependencies if running RULER tasks
+{% if env_vars.MAX_SEQ_LENGTH %}
+echo "Installing RULER dependencies (wonderwords, nltk)..."
+pip install --no-cache-dir wonderwords nltk
+echo "RULER dependencies installed successfully"
+{% endif %}
+
 # Create a temporary directory for lm_eval output
 RANDOM_DIR="/tmp/lm_eval_$(date +%s%N)"
 mkdir -p "$RANDOM_DIR"

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -427,10 +427,10 @@ BATCH_SIZE="auto"
 BATCH_SIZE="4"
 {% endif %}
 
-{% if env_vars.TASK_METADATA %}
-# Set up metadata for RULER tasks
-TASK_METADATA_FLAG="--metadata '{{ env_vars.TASK_METADATA }}'"
-echo "Using task metadata: {{ env_vars.TASK_METADATA }}"
+{% if env_vars.MAX_SEQ_LENGTH %}
+# Set up metadata for RULER tasks - properly escaped for bash
+TASK_METADATA_FLAG="--metadata {\\\"max_seq_lengths\\\":[{{ env_vars.MAX_SEQ_LENGTH }}]}"
+echo "Using RULER metadata for sequence length: {{ env_vars.MAX_SEQ_LENGTH }}"
 {% else %}
 TASK_METADATA_FLAG=""
 {% endif %}

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -71,7 +71,39 @@ MODEL_ID="${MODEL_ID:?MODEL_ID not set}"
 TP="${TP:-4}"
 MODEL_SAFE="${MODEL_ID//\//-}"
 PREFETCH_LOCAL_DIR="/project/hf_cache/models/${MODEL_SAFE}"
-MODEL_LOCAL="${PREFETCH_LOCAL_DIR}"
+
+# Detect if MODEL_ID is a local path or a HuggingFace repo
+if [[ "$MODEL_ID" == /* ]] || [[ "$MODEL_ID" == ./* ]]; then
+    # Local path - convert to container path if needed
+    echo "Detected local model path: $MODEL_ID"
+    
+    # The host bind mount is: /scratch/{{ slurm_config.account }} -> /project
+    # So we need to replace /scratch/{{ slurm_config.account }} with /project
+    HOST_PROJECT_PATH="/scratch/{{ slurm_config.account }}"
+    
+    if [[ "$MODEL_ID" == "$HOST_PROJECT_PATH"* ]]; then
+        # Path is under the bind-mounted project directory
+        MODEL_LOCAL="/project${MODEL_ID#$HOST_PROJECT_PATH}"
+        echo "Converted to container path: $MODEL_LOCAL"
+    elif [[ "$MODEL_ID" == /pfs/lustrep*/scratch/{{ slurm_config.account }}* ]]; then
+        # Alternative PFS path format
+        MODEL_LOCAL="${MODEL_ID#/pfs/lustrep*/scratch/{{ slurm_config.account }}}"
+        MODEL_LOCAL="/project${MODEL_LOCAL}"
+        echo "Converted PFS path to container path: $MODEL_LOCAL"
+    else
+        # Path is not in the bind mount - this might fail
+        echo "WARNING: Model path is not under /scratch/{{ slurm_config.account }}"
+        echo "         This may not be accessible in the container."
+        MODEL_LOCAL="$MODEL_ID"
+    fi
+    
+    IS_LOCAL_MODEL=true
+else
+    # HuggingFace repo - will be downloaded
+    echo "Detected HuggingFace model: $MODEL_ID"
+    MODEL_LOCAL="${PREFETCH_LOCAL_DIR}"
+    IS_LOCAL_MODEL=false
+fi
 
 # ---- env & caches (disable xet + telemetry) ----
 export HF_HUB_DISABLE_XET=1
@@ -167,7 +199,8 @@ print("[stage] aiter import OK")
 PY
 
 {% if env_vars.BACKEND != "dummy" %}
-# ------- write helper: prefetch.py -------
+# ------- write helper: prefetch.py (only for HuggingFace models) -------
+if [ "$IS_LOCAL_MODEL" = "false" ]; then
 cat > /workspace/tools/prefetch.py <<PY
 from huggingface_hub import snapshot_download
 p = snapshot_download(
@@ -178,6 +211,7 @@ p = snapshot_download(
 )
 print("prefetch OK ->", p)
 PY
+fi
 {% endif %}
 
 # ------- write helper: sanity.py -------
@@ -194,10 +228,30 @@ PY
 # ------- run the helpers from files (no <stdin>) -------
 python /workspace/tools/sanity.py
 python /workspace/tools/stage_aiter.py
-{% if env_vars.BACKEND != "dummy" %}
-python /workspace/tools/prefetch.py
 
-# Model is prefetched, but allow datasets to be downloaded as needed
+{% if env_vars.BACKEND != "dummy" %}
+# Prefetch model if it's a HuggingFace repo (skip for local models)
+if [ "$IS_LOCAL_MODEL" = "false" ]; then
+    echo "Downloading model from HuggingFace..."
+    python /workspace/tools/prefetch.py
+    echo "Model download complete."
+else
+    echo "Using local model at: $MODEL_LOCAL"
+    # Verify the model directory exists
+    if [ ! -d "$MODEL_LOCAL" ]; then
+        echo "ERROR: Local model directory not found: $MODEL_LOCAL"
+        echo "Original MODEL_ID: $MODEL_ID"
+        exit 1
+    fi
+    if [ ! -f "$MODEL_LOCAL/config.json" ]; then
+        echo "ERROR: config.json not found in model directory: $MODEL_LOCAL"
+        echo "This does not appear to be a valid model directory."
+        exit 1
+    fi
+    echo "Local model validation passed."
+fi
+
+# Datasets will be downloaded as needed
 # Note: Datasets will be cached automatically for subsequent runs
 {% endif %}
 

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -248,7 +248,7 @@ python /workspace/tools/sanity.py
 python /workspace/tools/stage_aiter.py
 
 {% if env_vars.BACKEND != "dummy" %}
-# Prefetch model if it's a HuggingFace repo (skip for local models)
+# Prefetch model if it's a HuggingFace repo and skip for local models
 if [ "$IS_LOCAL_MODEL" = "false" ]; then
     echo "Downloading model from HuggingFace..."
     python /workspace/tools/prefetch.py

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -221,7 +221,7 @@ PY
 
 {% if env_vars.BACKEND != "dummy" %}
 # ------- write helper: prefetch.py (only for HuggingFace models) -------
-if [ "$IS_LOCAL_MODEL" = "false" ]; then
+if [[ "${IS_LOCAL_MODEL:-false}" == "false" ]]; then
 cat > /workspace/tools/prefetch.py <<PY
 from huggingface_hub import snapshot_download
 p = snapshot_download(
@@ -252,19 +252,19 @@ python /workspace/tools/stage_aiter.py
 
 {% if env_vars.BACKEND != "dummy" %}
 # Prefetch model if it's a HuggingFace repo and skip for local models
-if [ "$IS_LOCAL_MODEL" = "false" ]; then
+if [[ "${IS_LOCAL_MODEL:-false}" == "false" ]]; then
     echo "Downloading model from HuggingFace..."
     python /workspace/tools/prefetch.py
     echo "Model download complete."
 else
     echo "Using local model at: $MODEL_LOCAL"
     # Verify the model directory exists
-    if [ ! -d "$MODEL_LOCAL" ]; then
+    if [[ ! -d "$MODEL_LOCAL" ]]; then
         echo "ERROR: Local model directory not found: $MODEL_LOCAL"
         echo "Original MODEL_ID: $MODEL_ID"
         exit 1
     fi
-    if [ ! -f "$MODEL_LOCAL/config.json" ]; then
+    if [[ ! -f "$MODEL_LOCAL/config.json" ]]; then
         echo "ERROR: config.json not found in model directory: $MODEL_LOCAL"
         echo "This does not appear to be a valid model directory."
         exit 1

--- a/test_ruler_files.sh
+++ b/test_ruler_files.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Quick diagnostic to see what RULER files exist and what the script is looking for
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <DIR>"
+    exit 1
+fi
+
+DIR=$1
+
+echo "Looking in directory: $DIR"
+echo ""
+
+# Show all vllm_ruler files
+echo "=== Files matching vllm_ruler_*.json ==="
+ls -1 "$DIR"/vllm_ruler_*.json 2>/dev/null | head -20
+echo ""
+
+# Show all ruler files (non-vllm)
+echo "=== Files matching ruler_*.json (non-vllm) ==="
+ls -1 "$DIR"/ruler_*.json 2>/dev/null | grep -v "^vllm_" | head -20
+echo ""
+
+# Test the find_file logic
+echo "=== Testing find_file logic ==="
+SUBTASKS=("niah_single_1" "niah_single_2" "ruler_vt")
+SEQLEN=4096
+
+for subtask in "${SUBTASKS[@]}"; do
+    file1="$DIR/ruler_${subtask}_${SEQLEN}.json"
+    file2="$DIR/vllm_ruler_${subtask}_${SEQLEN}.json"
+    
+    echo "Checking for subtask: $subtask at length $SEQLEN"
+    echo "  Looking for: ruler_${subtask}_${SEQLEN}.json"
+    if [ -f "$file1" ]; then
+        echo "    ✓ Found (regular)"
+    else
+        echo "    ✗ Not found"
+    fi
+    
+    echo "  Looking for: vllm_ruler_${subtask}_${SEQLEN}.json"
+    if [ -f "$file2" ]; then
+        echo "    ✓ Found (vllm)"
+        
+        # Try to extract a result
+        echo "    Trying to extract result..."
+        result=$(cat "$file2" | jq -r ".results[\"$subtask\"][\"acc,none\"] // .results[\"$subtask\"][\"exact_match,none\"] // \"na\"" 2>/dev/null)
+        echo "    Result: $result"
+        
+        # Show available keys
+        echo "    Available result keys:"
+        cat "$file2" | jq -r '.results | keys[]' 2>/dev/null | head -5
+    else
+        echo "    ✗ Not found"
+    fi
+    echo ""
+done
+

--- a/test_ruler_files.sh
+++ b/test_ruler_files.sh
@@ -43,14 +43,14 @@ for subtask in "${SUBTASKS[@]}"; do
     if [ -f "$file2" ]; then
         echo "    ✓ Found (vllm)"
         
-        # Try to extract a result
+        # Try to extract a result using the correct format (with seqlen)
         echo "    Trying to extract result..."
-        result=$(cat "$file2" | jq -r ".results[\"$subtask\"][\"acc,none\"] // .results[\"$subtask\"][\"exact_match,none\"] // \"na\"" 2>/dev/null)
-        echo "    Result: $result"
+        result=$(cat "$file2" | jq -r ".results[\"$subtask\"][\"${SEQLEN},none\"] // .results[\"$subtask\"][\"acc,none\"] // .results[\"$subtask\"][\"exact_match,none\"] // \"na\"" 2>/dev/null)
+        echo "    Result (using ${SEQLEN},none): $result"
         
         # Show available keys
-        echo "    Available result keys:"
-        cat "$file2" | jq -r '.results | keys[]' 2>/dev/null | head -5
+        echo "    Available result keys for $subtask:"
+        cat "$file2" | jq -r ".results[\"$subtask\"] | keys[]" 2>/dev/null | head -10
     else
         echo "    ✗ Not found"
     fi

--- a/tests/test_container_migration.py
+++ b/tests/test_container_migration.py
@@ -1,0 +1,807 @@
+#!/usr/bin/env python3
+"""
+Comprehensive test suite for lm_eval_harness.sh container migration.
+
+Tests all backends, GPU configurations, eval types, path mappings, and edge cases.
+
+Usage:
+    python test_container_migration.py --dry-run          # Show what would run
+    python test_container_migration.py --run              # Submit jobs
+    python test_container_migration.py --run --tier core  # Run only core tests
+    python test_container_migration.py --check            # Check job results
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Tuple
+
+# =============================================================================
+# CONFIGURATION - UPDATE THESE
+# =============================================================================
+
+# Models
+MODEL_SMALL = "meta-llama/Llama-3.2-1B"          # Small, public, fast
+MODEL_LARGE = "meta-llama/Llama-3.1-8B-Instruct" # Larger, gated, needs HF_TOKEN
+MODEL_LOCAL = "/scratch/project_462000963/cache/huggingface/hub/models--meta-llama--Llama-2-7b-hf/snapshots/01c7f73d771dfac7d292323805ebc428287df4f9"  # Local cached model
+
+# Output
+OUTPUT_ROOT = "./test_output/container_migration"
+
+# SLURM
+PARTITION = "dev-g"  # 2-job limit but faster queue
+TIME_SHORT = "00:30:00"
+TIME_LONG = "01:00:00"
+
+# Test size
+LIMIT = 20  # Samples per task
+
+# =============================================================================
+# COMPREHENSIVE TEST STRATEGY - 3 TIERS
+# =============================================================================
+#
+# TIER 1 - CORE (Must pass for merge): 5 jobs
+#   - vLLM backend basics (1 GPU)
+#   - HF backend parity (1 GPU)
+#   - Multi-GPU tensor parallelism (8 GPU)
+#   - Dummy backend (no GPU)
+#   - Custom config (lm_eval repo, transformers version)
+#
+# TIER 2 - EXTENDED (Recommended): 6 jobs
+#   - Multilingual evals (Finnish, Swedish)
+#   - Generation tasks (lambada, triviaqa)
+#   - 4 GPU intermediate config
+#   - Chat template variations
+#   - Multiple evals in single job
+#   - Local model path (if configured)
+#
+# TIER 3 - EDGE CASES (Optional): 4 jobs
+#   - Trust remote code
+#   - Custom tokenizer
+#   - Various model_args combinations
+#   - Batch size variations
+#
+# =============================================================================
+
+@dataclass
+class TestJob:
+    name: str
+    description: str
+    tasks: List[str]  # Multiple tasks in one job
+    model: str
+    backend: str
+    tier: str = "core"  # core, extended, edge
+    gres: str = "gpu:mi250:1"
+    time: str = TIME_SHORT
+    extra_args: List[str] = field(default_factory=list)
+    checks: List[str] = field(default_factory=list)  # What to verify
+    skip_if: str = ""  # Condition to skip (e.g., "no_local_model")
+
+
+# =============================================================================
+# TIER 1: CORE TESTS (Must pass for merge)
+# =============================================================================
+
+CORE_TESTS = [
+    TestJob(
+        name="vllm_1gpu_scoring",
+        description="vLLM backend: loglikelihood scoring task",
+        tier="core",
+        tasks=["arc_easy"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        checks=[
+            "output_json_valid",
+            "output_path_correct",
+            "has_arc_easy_results",
+            "gpu_count:1",
+            "log_contains:vLLM:",
+        ],
+    ),
+    TestJob(
+        name="hf_1gpu_scoring",
+        description="HF backend: same task for parity comparison",
+        tier="core",
+        tasks=["arc_easy"],
+        model=MODEL_SMALL,
+        backend="hf",
+        gres="gpu:mi250:1",
+        time=TIME_LONG,
+        checks=[
+            "output_json_valid",
+            "has_arc_easy_results",
+            "parity:vllm_1gpu_scoring:arc_easy",
+        ],
+    ),
+    TestJob(
+        name="vllm_8gpu_tp",
+        description="vLLM 8 GPU tensor parallelism with chat template",
+        tier="core",
+        tasks=["arc_challenge"],
+        model=MODEL_LARGE,
+        backend="vllm",
+        gres="gpu:mi250:8",
+        extra_args=["--apply_chat_template", "--fewshot_as_multiturn"],
+        checks=[
+            "output_json_valid",
+            "gpu_count:8",
+            "has_arc_challenge_results",
+            "log_contains:tensor_parallel_size=8",
+        ],
+    ),
+    TestJob(
+        name="dummy_backend",
+        description="Dummy backend (cache-only, no GPU needed)",
+        tier="core",
+        tasks=["arc_easy"],
+        model=MODEL_SMALL,
+        backend="dummy",
+        gres="gpu:mi250:1",
+        extra_args=["--limit", "5"],  # Very small for dummy
+        checks=[
+            "output_json_valid",
+            "has_arc_easy_results",
+        ],
+    ),
+    TestJob(
+        name="custom_lm_eval_repo",
+        description="Custom lm-eval repo (EleutherAI upstream)",
+        tier="core",
+        tasks=["arc_easy"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        extra_args=[
+            "--lm_eval", "https://github.com/EleutherAI/lm-evaluation-harness@main",
+        ],
+        checks=[
+            "output_json_valid",
+            "has_arc_easy_results",
+            "log_contains:EleutherAI/lm-evaluation-harness",
+        ],
+    ),
+]
+
+# =============================================================================
+# TIER 2: EXTENDED TESTS (Recommended)
+# =============================================================================
+
+EXTENDED_TESTS = [
+    TestJob(
+        name="multilingual_fi",
+        description="Multilingual: Finnish HellaSwag",
+        tier="extended",
+        tasks=["hellaswag_mt_fi"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        checks=[
+            "output_json_valid",
+            "has_hellaswag_mt_fi_results",
+        ],
+    ),
+    TestJob(
+        name="multilingual_sv",
+        description="Multilingual: Swedish ARC",
+        tier="extended",
+        tasks=["arc_challenge_mt_sv"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        checks=[
+            "output_json_valid",
+            "has_arc_challenge_mt_sv_results",
+        ],
+    ),
+    TestJob(
+        name="generation_task",
+        description="Generation task: lambada_openai",
+        tier="extended",
+        tasks=["lambada_openai"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        checks=[
+            "output_json_valid",
+            "has_lambada_openai_results",
+        ],
+    ),
+    TestJob(
+        name="vllm_4gpu_tp",
+        description="vLLM 4 GPU intermediate config",
+        tier="extended",
+        tasks=["arc_easy"],
+        model=MODEL_LARGE,
+        backend="vllm",
+        gres="gpu:mi250:4",
+        extra_args=["--apply_chat_template"],
+        checks=[
+            "output_json_valid",
+            "gpu_count:4",
+            "has_arc_easy_results",
+            "log_contains:tensor_parallel_size=4",
+        ],
+    ),
+    TestJob(
+        name="multi_task_single_job",
+        description="Multiple evals in single job",
+        tier="extended",
+        tasks=["arc_easy", "hellaswag", "piqa"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        checks=[
+            "output_json_valid",
+            "output_path_correct",
+            "has_arc_easy_results",
+            "has_hellaswag_results",
+            "has_piqa_results",
+        ],
+    ),
+    TestJob(
+        name="local_model_path",
+        description="Local checkpoint path (tests path mapping)",
+        tier="extended",
+        tasks=["arc_easy"],
+        model=MODEL_LOCAL,
+        backend="vllm",
+        gres="gpu:mi250:4",
+        skip_if="no_local_model",
+        checks=[
+            "output_json_valid",
+            "has_arc_easy_results",
+            "log_contains:/project",  # Path should be remapped
+        ],
+    ),
+    # Test from PR #7 - fewshot variations
+    TestJob(
+        name="fewshot_10shot",
+        description="10-shot fewshot test (hellaswag default)",
+        tier="extended",
+        tasks=["hellaswag"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        checks=[
+            "output_json_valid",
+            "has_hellaswag_results",
+        ],
+    ),
+]
+
+# =============================================================================
+# TIER 3: EDGE CASE TESTS (Optional)
+# =============================================================================
+
+EDGE_TESTS = [
+    TestJob(
+        name="custom_model_args",
+        description="Custom model_args (max_model_len, dtype)",
+        tier="edge",
+        tasks=["arc_easy"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        extra_args=[
+            "--model_args", "max_model_len=2048,dtype=float16",
+        ],
+        checks=[
+            "output_json_valid",
+            "has_arc_easy_results",
+            "log_contains:max_model_len=2048",
+        ],
+    ),
+    TestJob(
+        name="custom_batch_size",
+        description="Custom batch size (8)",
+        tier="edge",
+        tasks=["arc_easy"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        extra_args=[
+            "--batch_size", "8",
+        ],
+        checks=[
+            "output_json_valid",
+            "has_arc_easy_results",
+        ],
+    ),
+    TestJob(
+        name="trust_remote_code",
+        description="Trust remote code flag",
+        tier="edge",
+        tasks=["arc_easy"],
+        model=MODEL_SMALL,
+        backend="vllm",
+        gres="gpu:mi250:1",
+        extra_args=[
+            "--trust_remote_code",
+        ],
+        checks=[
+            "output_json_valid",
+            "has_arc_easy_results",
+        ],
+    ),
+]
+
+# Combine all tests
+TEST_JOBS = CORE_TESTS + EXTENDED_TESTS + EDGE_TESTS
+
+
+# =============================================================================
+# VALIDATION
+# =============================================================================
+
+class Validator:
+    def __init__(self, output_root: Path, log_dir: Path):
+        self.output_root = output_root
+        self.log_dir = log_dir
+        self.all_results = {}  # Cache for parity checks
+
+    def run_checks(self, job: TestJob, job_id: str) -> list[tuple[str, bool, str]]:
+        """Run all checks for a job, return list of (check_name, passed, message)."""
+        results = []
+        output_dir = self.output_root / job.name
+
+        for check in job.checks:
+            passed, msg = self._run_check(check, job, output_dir, job_id)
+            results.append((check, passed, msg))
+
+        return results
+
+    def _run_check(self, check: str, job: TestJob, output_dir: Path, job_id: str) -> tuple[bool, str]:
+        """Run a single check."""
+        log_path = self.log_dir / f"{job_id}.out"
+
+        # Parse check type
+        if check == "output_json_valid":
+            return self._check_json_valid(output_dir, job.tasks)
+
+        elif check.startswith("has_") and check.endswith("_results"):
+            task = check[4:-8]  # Extract task name
+            return self._check_has_task_results(output_dir, task)
+
+        elif check.startswith("gpu_count:"):
+            expected = int(check.split(":")[1])
+            return self._check_gpu_count(log_path, expected)
+
+        elif check.startswith("parity:"):
+            # Format: parity:other_job:task
+            parts = check.split(":")
+            other_job = parts[1]
+            task = parts[2] if len(parts) > 2 else job.tasks[0]
+            return self._check_parity(output_dir, other_job, [task])
+
+        elif check.startswith("log_contains:"):
+            pattern = check.split(":", 1)[1]
+            return self._check_log_contains(log_path, pattern)
+
+        elif check == "output_path_correct":
+            return self._check_output_path(output_dir, job)
+
+        return False, f"Unknown check: {check}"
+
+    def _check_output_path(self, output_dir: Path, job: TestJob) -> tuple[bool, str]:
+        """Check that output files are written to the expected directory."""
+        if not output_dir.exists():
+            return False, f"Output dir does not exist: {output_dir}"
+
+        # Find JSON files in output dir
+        json_files = list(output_dir.glob("*.json"))
+        if not json_files:
+            return False, f"No JSON files in {output_dir}"
+
+        # Verify each task has an output file
+        missing = []
+        for task in job.tasks:
+            # Check for both vllm_ prefixed and unprefixed files
+            found = any(
+                task in f.stem for f in json_files
+            )
+            if not found:
+                missing.append(task)
+
+        if missing:
+            return False, f"Missing output for tasks: {missing}"
+
+        return True, f"Output files in correct path: {output_dir.name}/ ({len(json_files)} files)"
+
+    def _check_log_contains(self, log_path: Path, pattern: str) -> tuple[bool, str]:
+        """Check that log file contains a pattern."""
+        if not log_path.exists():
+            return False, f"Log not found: {log_path}"
+
+        content = log_path.read_text()
+        if pattern in content:
+            return True, f"Found '{pattern}' in log"
+        return False, f"Pattern '{pattern}' not found in log"
+
+    def _check_json_valid(self, output_dir: Path, tasks: list[str]) -> tuple[bool, str]:
+        """Check that valid JSON output exists for each task."""
+        for task in tasks:
+            # Find JSON files containing the task name (handles timestamps in filenames)
+            # e.g., vllm_arc_easy_2026-01-27T13-52-57.json or arc_easy.json
+            matching_files = list(output_dir.glob(f"*{task}*.json"))
+            # Exclude samples files (jsonl files that got renamed)
+            matching_files = [f for f in matching_files if "samples_" not in f.name]
+
+            found = False
+            for path in matching_files:
+                try:
+                    with open(path) as f:
+                        data = json.load(f)
+                    if "results" in data:
+                        found = True
+                        self.all_results[f"{output_dir.name}:{task}"] = data
+                        break
+                except json.JSONDecodeError:
+                    return False, f"Invalid JSON in {path}"
+            if not found:
+                return False, f"No valid output for task {task}"
+        return True, f"All {len(tasks)} task outputs valid"
+
+    def _check_has_task_results(self, output_dir: Path, task: str) -> tuple[bool, str]:
+        """Check that results contain data for a specific task."""
+        key = f"{output_dir.name}:{task}"
+        if key not in self.all_results:
+            # Try to load it
+            for pattern in [f"{task}.json", f"vllm_{task}.json"]:
+                path = output_dir / pattern
+                if path.exists():
+                    with open(path) as f:
+                        self.all_results[key] = json.load(f)
+                    break
+
+        if key not in self.all_results:
+            return False, f"No results loaded for {task}"
+
+        data = self.all_results[key]
+        results = data.get("results", {})
+
+        # Check if any result key contains the task name
+        for result_key in results:
+            if task in result_key or task.replace("_", "") in result_key.replace("_", ""):
+                return True, f"Found results for {task}"
+
+        return False, f"No results matching {task} in output"
+
+    def _check_gpu_count(self, log_path: Path, expected: int) -> tuple[bool, str]:
+        """Verify GPU count from logs."""
+        if not log_path.exists():
+            return False, f"Log not found: {log_path}"
+
+        content = log_path.read_text()
+
+        # Look for "Devices: N" from PyTorch check
+        match = re.search(r"Devices:\s*(\d+)", content)
+        if match:
+            actual = int(match.group(1))
+            if actual >= expected:
+                return True, f"GPU count OK: {actual}"
+            return False, f"GPU count: expected {expected}, got {actual}"
+
+        # Fallback: look for "GPUs: N"
+        match = re.search(r"GPUs:\s*(\d+)", content)
+        if match:
+            actual = int(match.group(1))
+            if actual >= expected:
+                return True, f"GPU count OK: {actual}"
+            return False, f"GPU count: expected {expected}, got {actual}"
+
+        return False, "Could not determine GPU count"
+
+    def _check_parity(self, output_dir: Path, other_job: str, tasks: list[str]) -> tuple[bool, str]:
+        """Compare results with another job for parity."""
+        diffs = []
+        for task in tasks:
+            key1 = f"{output_dir.name}:{task}"
+            key2 = f"{other_job}:{task}"
+
+            if key1 not in self.all_results or key2 not in self.all_results:
+                return False, f"Missing results for parity check: {key1} or {key2}"
+
+            # Extract a comparable metric
+            r1 = self.all_results[key1].get("results", {})
+            r2 = self.all_results[key2].get("results", {})
+
+            # Find common metrics
+            for task_key in r1:
+                if task in task_key:
+                    m1 = r1[task_key]
+                    m2 = r2.get(task_key, {})
+
+                    # Compare acc or acc_norm
+                    for metric in ["acc,none", "acc_norm,none", "acc", "acc_norm"]:
+                        if metric in m1 and metric in m2:
+                            v1, v2 = m1[metric], m2[metric]
+                            diff = abs(v1 - v2)
+                            diffs.append((task, metric, v1, v2, diff))
+                            break
+
+        if not diffs:
+            return False, "No comparable metrics found"
+
+        # Check all diffs are within tolerance (2%)
+        max_diff = max(d[4] for d in diffs)
+        if max_diff < 0.02:
+            summary = ", ".join(f"{d[0]}:{d[4]:.4f}" for d in diffs)
+            return True, f"Parity OK (max diff {max_diff:.4f}): {summary}"
+        else:
+            summary = ", ".join(f"{d[0]}:{d[2]:.3f}vs{d[3]:.3f}" for d in diffs)
+            return False, f"Parity FAIL (diff {max_diff:.4f}): {summary}"
+
+
+# =============================================================================
+# TEST RUNNER
+# =============================================================================
+
+class TestRunner:
+    def __init__(self, output_root: str, dry_run: bool = False):
+        self.output_root = Path(output_root)
+        self.dry_run = dry_run
+        self.results_file = self.output_root / "test_results.json"
+        self.log_dir = self.output_root / "logs"
+
+    def setup(self):
+        self.output_root.mkdir(parents=True, exist_ok=True)
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+
+    def should_skip(self, job: TestJob) -> tuple[bool, str]:
+        """Check if job should be skipped."""
+        if job.skip_if == "no_local_model" and not job.model:
+            return True, "MODEL_LOCAL not configured"
+        return False, ""
+
+    def run_job(self, job: TestJob) -> dict:
+        """Submit a test job (may include multiple tasks)."""
+        skip, reason = self.should_skip(job)
+        if skip:
+            return {"name": job.name, "status": "skipped", "reason": reason}
+
+        output_dir = self.output_root / job.name
+
+        # Build command - run all tasks in one job
+        cmd = [
+            "python", "main.py",
+        ] + job.tasks + [
+            "--model", job.model,
+            "--backend", job.backend,
+            "--partition", PARTITION,
+            "--time", job.time,
+            "--gres", job.gres,
+            "--limit", str(LIMIT),
+            "--output_dir", str(output_dir),
+            "--log_dir", str(self.log_dir),
+            "--force",
+        ] + job.extra_args
+
+        print(f"\n{'='*60}")
+        print(f"JOB: {job.name}")
+        print(f"     {job.description}")
+        print(f"     Tasks: {', '.join(job.tasks)}")
+        print(f"     {job.gres}, {job.time}")
+        print(f"CMD: {' '.join(cmd)}")
+        print(f"{'='*60}")
+
+        if self.dry_run:
+            return {"name": job.name, "status": "dry-run", "cmd": " ".join(cmd)}
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+
+            # Parse job IDs (one per task)
+            job_ids = []
+            for line in result.stdout.split("\n"):
+                match = re.search(r'"job_id":\s*"(\d+)"', line)
+                if match:
+                    job_ids.append(match.group(1))
+
+            return {
+                "name": job.name,
+                "status": "submitted" if result.returncode == 0 else "failed",
+                "job_ids": job_ids,
+                "tasks": job.tasks,
+                "checks": job.checks,
+                "output_dir": str(output_dir),
+                "returncode": result.returncode,
+                "stdout": result.stdout[-2000:],  # Last 2000 chars
+                "stderr": result.stderr[-1000:] if result.stderr else "",
+            }
+        except subprocess.TimeoutExpired:
+            return {"name": job.name, "status": "timeout"}
+        except Exception as e:
+            return {"name": job.name, "status": "error", "error": str(e)}
+
+    def run_all(self, jobs: list[TestJob]) -> list[dict]:
+        """Run all test jobs."""
+        self.setup()
+        results = []
+
+        for job in jobs:
+            result = self.run_job(job)
+            results.append(result)
+
+        with open(self.results_file, "w") as f:
+            json.dump(results, f, indent=2)
+
+        self._print_summary(results)
+        return results
+
+    def check_results(self, jobs: list[TestJob]) -> list[dict]:
+        """Check results of previously submitted jobs."""
+        if not self.results_file.exists():
+            print("No results file. Run --run first.")
+            return []
+
+        with open(self.results_file) as f:
+            results = json.load(f)
+
+        validator = Validator(self.output_root, self.log_dir)
+        job_map = {j.name: j for j in jobs}
+
+        for r in results:
+            if r.get("status") != "submitted":
+                continue
+
+            # Check SLURM job status
+            job_ids = r.get("job_ids", [])
+            if job_ids:
+                statuses = [self._get_job_status(jid) for jid in job_ids]
+                r["job_statuses"] = statuses
+
+                # All completed?
+                if all(s == "COMPLETED" for s in statuses):
+                    r["job_status"] = "COMPLETED"
+                elif any(s == "FAILED" for s in statuses):
+                    r["job_status"] = "FAILED"
+                elif any(s in ("PENDING", "RUNNING") for s in statuses):
+                    r["job_status"] = "RUNNING"
+                else:
+                    r["job_status"] = "UNKNOWN"
+
+            # Run validation if completed
+            if r.get("job_status") == "COMPLETED":
+                job = job_map.get(r["name"])
+                if job:
+                    checks = validator.run_checks(job, job_ids[0] if job_ids else "")
+                    r["validation"] = [
+                        {"check": c, "passed": p, "message": m}
+                        for c, p, m in checks
+                    ]
+                    r["all_passed"] = all(p for _, p, _ in checks)
+
+        with open(self.results_file, "w") as f:
+            json.dump(results, f, indent=2)
+
+        self._print_check_summary(results)
+        return results
+
+    def _get_job_status(self, job_id: str) -> str:
+        try:
+            result = subprocess.run(
+                ["sacct", "-j", job_id, "--format=State", "--noheader", "-P"],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0:
+                states = result.stdout.strip().split("\n")
+                return states[0].strip() if states else "UNKNOWN"
+        except:
+            pass
+        return "UNKNOWN"
+
+    def _print_summary(self, results: list[dict]):
+        print(f"\n{'='*60}")
+        print("SUBMITTED JOBS")
+        print(f"{'='*60}")
+        for r in results:
+            status = r.get("status", "unknown")
+            if status == "submitted":
+                ids = ",".join(r.get("job_ids", []))
+                print(f"  OK  {r['name']}: jobs {ids}")
+            elif status == "skipped":
+                print(f"  --  {r['name']}: {r.get('reason', 'skipped')}")
+            elif status == "dry-run":
+                print(f"  >>  {r['name']}: {r.get('cmd', '')[:60]}...")
+            else:
+                print(f"  !!  {r['name']}: {status}")
+
+    def _print_check_summary(self, results: list[dict]):
+        print(f"\n{'='*60}")
+        print("VALIDATION RESULTS")
+        print(f"{'='*60}")
+        for r in results:
+            name = r["name"]
+            status = r.get("job_status", r.get("status", "unknown"))
+
+            if status == "skipped":
+                print(f"  --  {name}: skipped")
+            elif status != "COMPLETED":
+                print(f"  ..  {name}: {status}")
+            else:
+                validations = r.get("validation", [])
+                all_passed = r.get("all_passed", False)
+                icon = "OK" if all_passed else "!!"
+                print(f"  {icon}  {name}:")
+                for v in validations:
+                    mark = "+" if v["passed"] else "X"
+                    print(f"      [{mark}] {v['check']}: {v['message']}")
+
+    def clean(self):
+        import shutil
+        if self.output_root.exists():
+            shutil.rmtree(self.output_root)
+            print(f"Cleaned: {self.output_root}")
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(description="Test container migration")
+    parser.add_argument("--dry-run", action="store_true", help="Show commands without running")
+    parser.add_argument("--run", action="store_true", help="Submit test jobs")
+    parser.add_argument("--check", action="store_true", help="Check job results")
+    parser.add_argument("--clean", action="store_true", help="Clean test outputs")
+    parser.add_argument("--parity", action="store_true", help="Check backend parity")
+    parser.add_argument("--output", default=OUTPUT_ROOT, help="Output directory")
+    parser.add_argument("--filter", help="Only run tests matching this pattern")
+    parser.add_argument("--tier", choices=["core", "extended", "edge", "all"],
+                        default="all", help="Test tier to run (default: all)")
+    parser.add_argument("--list", action="store_true", help="List all available tests")
+
+    args = parser.parse_args()
+
+    if args.list:
+        print("\n=== CORE TESTS (required for merge) ===")
+        for j in CORE_TESTS:
+            print(f"  {j.name}: {j.description}")
+        print("\n=== EXTENDED TESTS (recommended) ===")
+        for j in EXTENDED_TESTS:
+            print(f"  {j.name}: {j.description}")
+        print("\n=== EDGE CASE TESTS (optional) ===")
+        for j in EDGE_TESTS:
+            print(f"  {j.name}: {j.description}")
+        print(f"\nTotal: {len(TEST_JOBS)} tests")
+        return
+
+    if not any([args.dry_run, args.run, args.check, args.clean]):
+        parser.print_help()
+        return
+
+    runner = TestRunner(args.output, dry_run=args.dry_run)
+
+    # Filter by tier
+    jobs = TEST_JOBS
+    if args.tier != "all":
+        if args.tier == "core":
+            jobs = CORE_TESTS
+        elif args.tier == "extended":
+            jobs = CORE_TESTS + EXTENDED_TESTS
+        elif args.tier == "edge":
+            jobs = TEST_JOBS  # All tiers
+        print(f"Running tier '{args.tier}': {len(jobs)} jobs")
+
+    # Filter by name pattern
+    if args.filter:
+        jobs = [j for j in jobs if args.filter in j.name]
+        print(f"Filtered to {len(jobs)} jobs matching '{args.filter}'")
+
+    if args.clean:
+        runner.clean()
+    elif args.run or args.dry_run:
+        runner.run_all(jobs)
+    elif args.check:
+        runner.check_results(jobs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Add RULER Long Context Evaluation Support

### Summary
Integrates [RULER (Rule-based Long-context Understanding Evaluation)](https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/ruler) benchmark from `lm-evaluation-harness` into the evaluation framework. RULER evaluates language models on their ability to retrieve and use information from long contexts (4K to 128K tokens).

### Key Features

**Granular Task Control**
- Support for all 13 RULER subtasks:
  - NIAH (Needle in a Haystack): `niah_single_1-3`, `niah_multikey_1-3`, `niah_multivalue`, `niah_multiquery`
  - Variable Tracking: `ruler_vt`
  - Word Extraction: `ruler_cwe`, `ruler_fwe`
  - Question Answering: `ruler_qa_hotpot`, `ruler_qa_squad`
- Support for 6 sequence lengths: 4096, 8192, 16384, 32768, 65536, 131072
- Run individual subtask-length combinations or batches via helper scripts

**Helper Scripts**
- `ruler.sh` - Run RULER with HuggingFace backend
- `ruler-vllm.sh` - Run RULER with vLLM backend (faster for large models)
- `summary_ruler.sh` - Dedicated summary script with sequence length comparison tables

**Documentation**
- `RULER_README.md` - Complete guide with examples
- `RULER_QUICK_REFERENCE.md` - Quick command reference

### Changes

#### New Files
- `ruler.sh` - RULER evaluation launcher (HF backend)
- `ruler-vllm.sh` - RULER evaluation launcher (vLLM backend)
- `summary_ruler.sh` - RULER-specific results summarization
- `RULER_README.md`, `RULER_QUICK_REFERENCE.md` - Documentation

#### Modified Files

**`evals/evals.py`**
- Added `RulerConfig` class with support for subtask and sequence length parameters
- Registered 78 RULER task combinations (13 subtasks × 6 lengths)
- Custom result parsing for RULER's unique metric format (`<seqlen>,none`)

**`evals/harnesses.py`**
- Added `metadata` parameter to `LMEvalHarness` for passing sequence length to tasks
- Conditional `MAX_SEQ_LENGTH` setting (only for RULER tasks)

**`templates/lm_eval_harness.sh`**
- Local model path detection and container path conversion
- Automatic RULER dependency installation (`wonderwords`, `nltk`)
- Forced `max_model_len`/`max_length` matching for RULER sequence lengths
- Improved output path handling for container environments
- RULER metadata flag generation with proper JSON escaping

**`summary.sh`**
- Added vLLM filename prefix support (`vllm_*.json`)
- Removed RULER-specific logic (delegated to `summary_ruler.sh`)

### Usage Examples

**Run single RULER task:**
```bash
sh ruler-vllm.sh meta-llama/Llama-3.1-8B \
  --subtasks "niah_single_1" \
  --sequence-lengths "4096"
```

**Run multiple subtasks at one sequence length:**
```bash
sh ruler-vllm.sh meta-llama/Llama-3.1-8B \
  --subtasks "niah_single_1,niah_single_2,niah_single_3" \
  --sequence-lengths "32768"
```

**Run full RULER suite:**
```bash
sh ruler-vllm.sh meta-llama/Llama-3.1-8B \
  --subtasks "all" \
  --sequence-lengths "4096,8192,16384,32768,65536,131072"
```

**Summarize results:**
```bash
sh summary_ruler.sh output/v2/Llama-3.1-8B
```

### Bug Fixes
- Fixed path conversion for local models in container environments
- Fixed unbound variable errors with proper initialization
- Fixed vLLM result file detection in summary script
- Fixed RULER metric parsing for sequence-length-specific keys

### Testing
Tested on LUMI HPC with:
- Local models (converted checkpoints)
- Both HF and vLLM backends
- Multiple sequence lengths (4K and 8K)
- All 13 RULER subtasks

### Breaking Changes
None. All changes are additive and backward compatible with existing evaluation tasks.

---

**Related Links:**
- RULER Paper: [arXiv:2404.06654](https://arxiv.org/abs/2404.06654)
- LM Eval Harness RULER: https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/ruler


