### PR TITLE
bugfix: remap local model paths to container bind mounts

### DIFF
--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -196,6 +196,13 @@ elif [[ "$OUTPUT_FILE" != /* ]]; then
 fi
 mkdir -p "$(dirname "$OUTPUT_FILE")"
 
+# Remap MODEL_ID from host paths to container paths if needed
+if [[ "$MODEL_ID" == /scratch/{{ slurm_config.account }}/* ]]; then
+  MODEL_ID="/project${MODEL_ID#/scratch/{{ slurm_config.account }}}"
+elif [[ "$MODEL_ID" == "$SCR"/* ]]; then
+  MODEL_ID="/workspace${MODEL_ID#$SCR}"
+fi
+
 # Set up chat template flags
 {% if env_vars.APPLY_CHAT_TEMPLATE %}
 CHAT_TEMPLATE_FLAG="--apply_chat_template"


### PR DESCRIPTION
this logic was naively removed in the last path related set of fixes, and breaks local checkpoint runs.
e.g,
`python main.py hellaswag --backend vllm --project project_462000963 --partition dev-g --gres gpu:mi250:8 --time 03:00:00 --model /scratch/project_462000963/users/jouni/CPT_from_finetuned/poro2-scripts-dev/converted-checkpoints/Poro2-long-8B-TP-2-PP-4-regular-sft/checkpoint_0000600/`

will fail on :

```
OSError: Can't load the configuration of '/scratch/project_462000963/users/jouni/CPT_from_finetuned/poro2-scripts-dev/converted-checkpoints/Poro2-long-8B-TP-2-PP-4-regular-sft/checkpoint_0000600/'. If you were trying to load it from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. Otherwise, make sure '/scratch/project_462000963/users/jouni/CPT_from_finetuned/poro2-scripts-dev/converted-checkpoints/Poro2-long-8B-TP-2-PP-4-regular-sft/checkpoint_0000600/' is the correct path to a directory containing a config.json file
srun: error: nid007956: task 0: Exited with exit code 1
```

this fixes it by mapping the /scratch paths to correct paths inside the container. it's a bit "ugly" but the alternative is to manually pass the container paths, which is terrible UX and will cause even more headache IMO....


tested it on both hugginface model id and on local checkpoint with hellaswag and both work. 
