### PR TITLE
migrate to lumi ai factory container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ command_history.jsonl
 .*.sw?
 __pycache__
 output
+test_output
 .local

--- a/cpt-vllm.sh
+++ b/cpt-vllm.sh
@@ -25,7 +25,7 @@ run() {
   local tasks=( "$@" )
 
   # Build args as an array to keep quoting correct
-  local args=( python main.py --backend "$BACKEND" --project "$PROJECT" --partition "$QUEUE" --model "$MODEL" --time "$t" )
+  local args=( python3 main.py --backend "$BACKEND" --project "$PROJECT" --partition "$QUEUE" --model "$MODEL" --time "$t" )
 
   # Only pass --gres if explicitly provided
   if [[ -n "$CPT_GRES" ]]; then
@@ -36,10 +36,10 @@ run() {
     args+=( --model_args "$MODEL_ARGS" )
   fi
   if [[ -n "$APPLY_CHAT_TEMPLATE" ]]; then
-    args+=( --apply_chat_template "$APPLY_CHAT_TEMPLATE" )
+    args+=( --apply_chat_template )
   fi
   if [[ -n "$FEWSHOT_AS_MULTITURN" ]]; then
-    args+=( --fewshot_as_multiturn "$FEWSHOT_AS_MULTITURN" )
+    args+=( --fewshot_as_multiturn )
   fi
 
   args+=( "${tasks[@]}" )

--- a/cpt.sh
+++ b/cpt.sh
@@ -2,7 +2,7 @@ QUEUE=standard-g
 PROJECT=project_462000963
 
 # this can go very long in models that are not good at this language, i guess?
-python main.py --time 12:00:00 --project $PROJECT --partition $QUEUE --model $1 flores200_trans_en_fi flores200_trans_fi_en
-python main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 arc_challenge arc_challenge_mt_fi truthfulqa_mc truthfulqa_mc_mt_fi goldenswag_mt_fi
-python main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 mmlu mmlu_mt_fi
-python main.py --time 48:00:00 --project $PROJECT --partition $QUEUE --model $1 gsm8k gsm8k_mt_fi hellaswag hellaswag_mt_fi goldenswag
+python3 main.py --time 12:00:00 --project $PROJECT --partition $QUEUE --model $1 flores200_trans_en_fi flores200_trans_fi_en
+python3 main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 arc_challenge arc_challenge_mt_fi truthfulqa_mc truthfulqa_mc_mt_fi goldenswag_mt_fi
+python3 main.py --time 10:00:00 --project $PROJECT --partition $QUEUE --model $1 mmlu mmlu_mt_fi
+python3 main.py --time 48:00:00 --project $PROJECT --partition $QUEUE --model $1 gsm8k gsm8k_mt_fi hellaswag hellaswag_mt_fi goldenswag

--- a/main.py
+++ b/main.py
@@ -125,7 +125,7 @@ def run_eval(eval_name, args):
 
     # Warn about experimental vLLM backend
     if backend == 'vllm':
-        print("⚠️  WARNING: vLLM backend is experimental. Performance and correctness have not been confirmed to be comparable with HuggingFace backend.")
+        print("WARNING: vLLM backend is experimental. Performance and correctness have not been confirmed to be comparable with HuggingFace backend.")
 
     # Create output filename with backend prefix for vLLM
     output_filename = f"vllm_{eval_name}.json" if backend == 'vllm' else f"{eval_name}.json"
@@ -154,7 +154,7 @@ def run_eval(eval_name, args):
         'LM_EVAL_REPO': lm_eval_config['LM_EVAL_REPO'],
         'LM_EVAL_REF': lm_eval_config['LM_EVAL_REF'],
         'LM_EVAL_PATH': lm_eval_config['LM_EVAL_PATH'],
-        'TRANSFORMERS_VERSION': args.transformers_version,
+        'TRANSFORMERS_VERSION': '4.57.1',  # Fixed version compatible with container's vLLM 0.12.0
     }
 
     job_name = f"vllm_{eval_name}" if backend == 'vllm' else eval_name
@@ -283,11 +283,10 @@ def main():
     parser.add_argument('--limit', type=int, help='Limit the number of examples per task (for testing purposes only)')
     parser.add_argument('--batch_size', type=str, default='', help='Batch size for inference (default: auto for vLLM, 4 for HF)')
     parser.add_argument('--lm_eval', type=str, help='lm-evaluation-harness source: URL, URL@ref, or local path (default: LumiOpen/main)')
-    parser.add_argument('--transformers_version', type=str, default='4.57.1', help='Transformers version to install in container (default: 4.57.1)')
     # slurm config
     parser.add_argument('--project', type=str, default="project_462000963", help="Project for sbatch job")
     parser.add_argument('--partition', type=str, default="small-g", help="Partition for sbatch job")
-    parser.add_argument('--gres', type=str, default="gpu:mi250:4", help="gres required for sbatch job")
+    parser.add_argument('--gres', type=str, default="gpu:mi250:8", help="gres required for sbatch job")
     parser.add_argument('--time', type=str, default="48:00:00", help="Time limit for sbatch job")
     parser.add_argument('--log_dir', type=str, default="./logs", help="Dir for slurm logs")
     parser.add_argument('--dependency', type=str, default=None, help="SLURM job dependency (e.g., afterok:12345)")

--- a/summary.sh
+++ b/summary.sh
@@ -8,89 +8,195 @@ if [ "$#" -ne 1 ]; then
 fi
 DIR=$1
 
-echo -n "    arc_challenge: "
-if [ -f $DIR/arc_challenge.json ] ; then 
-    cat $DIR/arc_challenge.json | jq '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/arc_challenge2.json ] ; then 
-    echo -n "   arc_challenge2: "
-    cat $DIR/arc_challenge2.json | jq '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' | awk '{print $1 * 100}'
-fi
+pick_file() {
+    local stem="$1"
 
-echo -n "        hellaswag: "
-if [ -f $DIR/hellaswag.json ] ; then
-    cat $DIR/hellaswag.json | jq '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/hellaswag2.json ] ; then
-    echo -n "       hellaswag2: "
-    cat $DIR/hellaswag2.json | jq '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' | awk '{print $1 * 100}'
-fi
+    local exact="$DIR/${stem}.json"
+    local exact_vllm="$DIR/vllm_${stem}.json"
 
-echo -n "       goldenswag: "
-if [ -f $DIR/goldenswag.json ] ; then
-    cat $DIR/goldenswag.json | jq '.results.goldenswag.acc_norm // .results.goldenswag["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
+    # Prefer legacy files when they exist and are non-empty.
+    if [ -s "$exact" ]; then
+        echo "$exact"
+        return
+    fi
+    if [ -s "$exact_vllm" ]; then
+        echo "$exact_vllm"
+        return
+    fi
 
+    # Otherwise accept timestamp-suffixed files and pick newest non-empty.
+    # Important: avoid accidentally matching *other* task stems that merely share a prefix.
+    # Example: for stem="arc_challenge", we want vllm_arc_challenge_<ts>.json
+    # but NOT vllm_arc_challenge_mt_fi_<ts>.json.
+    local candidates=()
+    local nonempty=()
+    local filtered=()
+
+    shopt -s nullglob
+    candidates=(
+        "$DIR/${stem}"_*.json
+        "$DIR/${stem}"-*.json
+        "$DIR/vllm_${stem}"_*.json
+        "$DIR/vllm_${stem}"-*.json
+    )
+    shopt -u nullglob
+
+    for f in "${candidates[@]}"; do
+        [ -s "$f" ] && nonempty+=("$f")
+    done
+
+    # Prefer files where the suffix right after "${stem}_" or "${stem}-" starts with a digit
+    # (our timestamped outputs begin with YYYY-...). This filters out e.g. "${stem}_mt_fi_...".
+    for f in "${nonempty[@]}"; do
+        local base base_no_prefix rest
+        base="$(basename -- "$f")"
+        base_no_prefix="$base"
+        base_no_prefix="${base_no_prefix#vllm_}"
+
+        if [[ "$base_no_prefix" == "${stem}_"* ]]; then
+            rest="${base_no_prefix#${stem}_}"
+            [[ "$rest" =~ ^[0-9] ]] && filtered+=("$f")
+        elif [[ "$base_no_prefix" == "${stem}-"* ]]; then
+            rest="${base_no_prefix#${stem}-}"
+            [[ "$rest" =~ ^[0-9] ]] && filtered+=("$f")
+        fi
+    done
+
+    if [ ${#filtered[@]} -gt 0 ]; then
+        nonempty=("${filtered[@]}")
+    fi
+
+    if [ ${#nonempty[@]} -gt 0 ]; then
+        ls -1t "${nonempty[@]}" 2>/dev/null | head -n 1
+        return
+    fi
+
+    echo ""
+}
+
+# Fallback: pick newest non-empty JSON in $DIR where jq_filter yields a value
+pick_file_by_jq() {
+    local jq_filter="$1"
+
+    local candidates=()
+    local nonempty=()
+    local matched=()
+
+    shopt -s nullglob
+    candidates=("$DIR"/*.json)
+    shopt -u nullglob
+
+    for f in "${candidates[@]}"; do
+        [ -s "$f" ] && nonempty+=("$f")
+    done
+
+    for f in "${nonempty[@]}"; do
+        local v
+        v="$(jq -r "$jq_filter" "$f" 2>/dev/null)"
+        if [ -n "$v" ] && [ "$v" != "null" ]; then
+            matched+=("$f")
+        fi
+    done
+
+    if [ ${#matched[@]} -gt 0 ]; then
+        ls -1t "${matched[@]}" 2>/dev/null | head -n 1
+        return
+    fi
+
+    echo ""
+}
+
+print_metric() {
+    # Args: label, stem, jq_filter, scale
+    local label="$1"
+    local stem="$2"
+    local jq_filter="$3"
+    local scale="${4:-1}"
+
+    echo -n "$label"
+    local file
+    file="$(pick_file "$stem")"
+
+    local val
+    if [ -n "$file" ]; then
+        val="$(jq -r "$jq_filter" "$file" 2>/dev/null)"
+    fi
+
+    # If stem selection fails (missing file or metric not in that file),
+    # fall back to scanning for a JSON where jq_filter yields a value.
+    if [ -z "$file" ] || [ -z "$val" ] || [ "$val" = "null" ]; then
+        file="$(pick_file_by_jq "$jq_filter")"
+        if [ -z "$file" ]; then
+            echo "na"
+            return
+        fi
+        val="$(jq -r "$jq_filter" "$file" 2>/dev/null)"
+        if [ -z "$val" ] || [ "$val" = "null" ]; then
+            echo "na"
+            return
+        fi
+    fi
+
+    awk -v v="$val" -v s="$scale" 'BEGIN { print v * s }'
+}
+
+print_metric_if_exists() {
+    # Like print_metric, but prints nothing if no file exists.
+    # Args: label, stem, jq_filter, scale
+    local label="$1"
+    local stem="$2"
+    local jq_filter="$3"
+    local scale="${4:-1}"
+
+    local file
+    file="$(pick_file "$stem")"
+    [ -z "$file" ] && return 0
+
+    print_metric "$label" "$stem" "$jq_filter" "$scale"
+}
+
+# --- core English benchmarks ---
+print_metric "    arc_challenge: " "arc_challenge" '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' 100
+print_metric_if_exists "   arc_challenge2: " "arc_challenge2" '.results.arc_challenge.acc_norm // .results.arc_challenge["acc_norm,none"]' 100
+
+print_metric "        hellaswag: " "hellaswag" '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' 100
+print_metric_if_exists "       hellaswag2: " "hellaswag2" '.results.hellaswag.acc_norm // .results.hellaswag["acc_norm,none"]' 100
+
+print_metric "       goldenswag: " "goldenswag" '.results.goldenswag.acc_norm // .results.goldenswag["acc_norm,none"]' 100
+
+# mmlu is special: historically either .results.mmlu["acc,none"] or per-subtask .results[].acc
 echo -n "             mmlu: "
-if [ -f $DIR/mmlu.json ] ; then
-    cat $DIR/mmlu.json | jq '[if .results.mmlu | has("acc,none") then .results.mmlu["acc,none"] else .results | .[] | .acc end] | add / length * 100'
+mmlu_file="$(pick_file "mmlu")"
+if [ -n "$mmlu_file" ]; then
+    jq -r '[if (.results.mmlu? | has("acc,none")) then .results.mmlu["acc,none"] else (.results | .[] | .acc) end] | add / length * 100' "$mmlu_file" 2>/dev/null \
+        | awk '{print $1}'
 else
     echo na
 fi
-if [ -f $DIR/mmlu2.json ] ; then
-    echo -n "            mmlu2: "
-    cat $DIR/mmlu2.json | jq '.results.mmlu."acc,none"' | awk '{print $1 * 100}'
-fi
+print_metric_if_exists "            mmlu2: " "mmlu2" '.results.mmlu."acc,none"' 100
 
-echo -n "    truthfulqa_mc: "
-if [ -f $DIR/truthfulqa_mc.json ] ; then 
-    cat $DIR/truthfulqa_mc.json | jq '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc2["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/truthfulqa_mc2.json ] ; then 
-    echo -n "   truthfulqa_mc2: "
-    cat $DIR/truthfulqa_mc.json | jq '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc2["acc,none"]' | awk '{print $1 * 100}'
-fi
+# truthfulqa_mc: keep original fallbacks but avoid cat|jq and allow timestamped/vllm names
+print_metric "    truthfulqa_mc: " "truthfulqa_mc" '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc["acc,none"] // .results.truthfulqa_mc2["acc,none"]' 100
+print_metric_if_exists "   truthfulqa_mc2: " "truthfulqa_mc2" '.results.truthfulqa_mc.mc2 // .results.truthfulqa_mc["acc,none"] // .results.truthfulqa_mc2["acc,none"]' 100
 
-echo -n "       winogrande: "
-if [ -f $DIR/winogrande.json ] ; then
-   cat $DIR/winogrande.json | jq '.results.winogrande.acc // .results.winogrande["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/winogrande2.json ] ; then
-    echo -n "      winogrande2: "
-   cat $DIR/winogrande2.json | jq '.results.winogrande.acc // .results.winogrande["acc,none"]' | awk '{print $1 * 100}'
-fi
+print_metric "       winogrande: " "winogrande" '.results.winogrande.acc // .results.winogrande["acc,none"]' 100
+print_metric_if_exists "      winogrande2: " "winogrande2" '.results.winogrande.acc // .results.winogrande["acc,none"]' 100
 
-echo -n "            gsm8k: "
-if [ -f $DIR/gsm8k.json ] ; then
-    cat $DIR/gsm8k.json | jq '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-if [ -f $DIR/gsm8k2.json ] ; then
-    echo -n "           gsm8k2: "
-    cat $DIR/gsm8k2.json | jq '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' | awk '{print $1 * 100}'
-fi
+print_metric "            gsm8k: " "gsm8k" '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' 100
+print_metric_if_exists "           gsm8k2: " "gsm8k2" '.results.gsm8k.acc // .results.gsm8k["exact_match,flexible-extract"]' 100
 
 echo
 
+# --- finbench (needs content sniff) ---
 echo -n "     finbench_3shot: "
-if [ -f $DIR/finbench_3shot.json ] ; then 
-    if grep FIN-bench $DIR/finbench_3shot.json > /dev/null 2>&1 ; then 
-        # new version
-        cat $DIR/finbench_3shot.json | jq  '.results | to_entries | map(.value."acc,none") | add / length' | awk '{print $1 * 100}'
+fin_file="$(pick_file "finbench_3shot")"
+if [ -z "$fin_file" ]; then
+    echo na
+else
+    if grep -q "FIN-bench" "$fin_file" >/dev/null 2>&1; then
+        jq -r '.results | to_entries | map(.value."acc,none") | add / length' "$fin_file" 2>/dev/null | awk '{print $1 * 100}'
     else
-        # old version
-        cat $DIR/finbench_3shot.json | jq  '.results | 
+        jq -r '.results |
             [
             .bigbench_1_digit_addition.multiple_choice_grade,
             .bigbench_1_digit_division.multiple_choice_grade,
@@ -134,547 +240,163 @@ if [ -f $DIR/finbench_3shot.json ] ; then
         ]
         } | {
         overall_average: ((.other) | add / length)
-        } | .overall_average' | awk '{print $1 * 100}'
+        } | .overall_average' "$fin_file" 2>/dev/null | awk '{print $1 * 100}'
     fi
-
-else
-    echo na
 fi
 
-echo -n "   arc_challenge_fi: "
-if [ -f $DIR/arc_challenge_fi.json ] ; then 
-    cat $DIR/arc_challenge_fi.json | jq '.results.arc_challenge_fi.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_fi.json ] ; then 
-    cat $DIR/arc_challenge_mt_fi.json | jq '.results.arc_challenge_mt_fi["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    hellaswag_mt_fi: "
-if [ -f $DIR/hellaswag_mt_fi.json ] ; then
-    cat $DIR/hellaswag_mt_fi.json | jq '.results.ogx_hellaswagx_fi."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n "    goldenswag_mt_fi: "
-if [ -f $DIR/goldenswag_mt_fi.json ] ; then
-    cat $DIR/goldenswag_mt_fi.json | jq '.results.ogx_goldenswagx_fi."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "         mmlu_mt_fi: "
-if [ -f $DIR/mmlu_mt_fi.json ] ; then
-    cat $DIR/mmlu_mt_fi.json | jq '.groups.ogx_mmlux_FI."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "truthfulqa_mc_mt_fi: "
-if [ -f $DIR/truthfulqa_mc_mt_fi.json ] ; then
-    cat $DIR/truthfulqa_mc_mt_fi.json | jq '.results.ogx_truthfulqax_mc2_fi."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "        gsm8k_mt_fi: "
-if [ -f $DIR/gsm8k_mt_fi.json ] ; then
-    cat $DIR/gsm8k_mt_fi.json | jq '.results.ogx_gsm8kx_fi."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
+# --- Finnish MT suite ---
+print_metric "   arc_challenge_fi: " "arc_challenge_mt_fi" '.results.arc_challenge_fi.acc_norm // .results.arc_challenge_mt_fi["acc_norm,none"] // .results.arc_challenge_fi["acc_norm,none"]' 100
+print_metric "    hellaswag_mt_fi: " "hellaswag_mt_fi" '.results.ogx_hellaswagx_fi."acc,none"' 100
+print_metric "    goldenswag_mt_fi: " "goldenswag_mt_fi" '.results.ogx_goldenswagx_fi."acc,none"' 100
+print_metric "         mmlu_mt_fi: " "mmlu_mt_fi" '.groups.ogx_mmlux_FI."acc,none"' 100
+print_metric "truthfulqa_mc_mt_fi: " "truthfulqa_mc_mt_fi" '.results.ogx_truthfulqax_mc2_fi."acc,none"' 100
+print_metric "        gsm8k_mt_fi: " "gsm8k_mt_fi" '.results.ogx_gsm8kx_fi."acc,none"' 100
 
 echo
 
-echo -n "    flores200_en_fi bleu: "
-if [ -f $DIR/flores200_trans_en_fi.json ] ; then
-    cat $DIR/flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+print_metric "    flores200_en_fi bleu: " "flores200_trans_en_fi" '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_fi_en bleu: " "flores200_trans_fi_en" '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_en_fi chrf: " "flores200_trans_en_fi" '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."chrf,none"' 1
+print_metric "    flores200_fi_en chrf: " "flores200_trans_fi_en" '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."chrf,none"' 1
 
-echo -n "    flores200_fi_en bleu: "
-if [ -f $DIR/flores200_trans_fi_en.json ] ; then
-    cat $DIR/flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+echo
+# --- Danish MT suite ---
+print_metric "   arc_challenge_da: " "arc_challenge_da" '.results.arc_challenge_da.acc_norm // .results.arc_challenge_mt_da["acc_norm,none"] // .results.arc_challenge_da["acc_norm,none"]' 100
+print_metric "    hellaswag_mt_da: " "hellaswag_mt_da" '.results.ogx_hellaswagx_da."acc,none"' 100
+print_metric "         mmlu_mt_da: " "mmlu_mt_da" '.groups.ogx_mmlux_DA."acc,none"' 100
+print_metric "truthfulqa_mc_mt_da: " "truthfulqa_mc_mt_da" '.results.ogx_truthfulqax_mc2_da."acc,none"' 100
+print_metric "        gsm8k_mt_da: " "gsm8k_mt_da" '.results.ogx_gsm8kx_da."acc,none"' 100
+print_metric "    flores200_en_da: " "flores200_trans_en_da" '.results."ogx_flores200-trans-eng_Latn-dan_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_da_en: " "flores200_trans_da_en" '.results."ogx_flores200-trans-dan_Latn-eng_Latn"."bleu_flores200,none"' 1
 
-echo -n "    flores200_en_fi chrf: "
-if [ -f $DIR/flores200_trans_en_fi.json ] ; then
-    cat $DIR/flores200_trans_en_fi.json | jq '.results."ogx_flores200-trans-eng_Latn-fin_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+echo
+# --- Icelandic ---
+print_metric " arc_challenge_is: " "arc_challenge_is" '.results.arc_challenge_is.acc_norm // .results.arc_challenge_mt_is["acc_norm,none"] // .results.arc_challenge_is["acc_norm,none"]' 100
+print_metric "    flores200_en_is: " "flores200_trans_en_is" '.results."ogx_flores200-trans-eng_Latn-isl_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_is_en: " "flores200_trans_is_en" '.results."ogx_flores200-trans-isl_Latn-eng_Latn"."bleu_flores200,none"' 1
 
-echo -n "    flores200_fi_en chrf: "
-if [ -f $DIR/flores200_trans_fi_en.json ] ; then
-    cat $DIR/flores200_trans_fi_en.json | jq '.results."ogx_flores200-trans-fin_Latn-eng_Latn"."chrf,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+echo
+# --- Norwegian Bokmal ---
+print_metric " arc_challenge_nb: " "arc_challenge_nb" '.results.arc_challenge_nb.acc_norm // .results.arc_challenge_mt_nb["acc_norm,none"] // .results.arc_challenge_nb["acc_norm,none"]' 100
+print_metric "    flores200_en_nb: " "flores200_trans_en_nb" '.results."ogx_flores200-trans-eng_Latn-nob_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_nb_en: " "flores200_trans_nb_en" '.results."ogx_flores200-trans-nob_Latn-eng_Latn"."bleu_flores200,none"' 1
 
+echo
+# --- Swedish ---
+print_metric "   arc_challenge_sv: " "arc_challenge_sv" '.results.arc_challenge_sv.acc_norm // .results.arc_challenge_mt_sv["acc_norm,none"] // .results.arc_challenge_sv["acc_norm,none"]' 100
+print_metric "    hellaswag_mt_sv: " "hellaswag_mt_sv" '.results.ogx_hellaswagx_sv."acc,none"' 100
+print_metric "         mmlu_mt_sv: " "mmlu_mt_sv" '.groups.ogx_mmlux_SV."acc,none"' 100
+print_metric "truthfulqa_mc_mt_sv: " "truthfulqa_mc_mt_sv" '.results.ogx_truthfulqax_mc2_sv."acc,none"' 100
+print_metric "        gsm8k_mt_sv: " "gsm8k_mt_sv" '.results.ogx_gsm8kx_sv."acc,none"' 100
+print_metric "    flores200_en_sv: " "flores200_trans_en_sv" '.results."ogx_flores200-trans-eng_Latn-swe_Latn"."bleu_flores200,none"' 1
+print_metric "    flores200_sv_en: " "flores200_trans_sv_en" '.results."ogx_flores200-trans-swe_Latn-eng_Latn"."bleu_flores200,none"' 1
+
+echo
+# --- arc_challenge (other languages) ---
+print_metric " arc_challenge_de: " "arc_challenge_de" '.results.arc_challenge_de.acc_norm // .results.arc_challenge_mt_de["acc_norm,none"] // .results.arc_challenge_de["acc_norm,none"]' 100
+print_metric " arc_challenge_el: " "arc_challenge_el" '.results.arc_challenge_el.acc_norm // .results.arc_challenge_mt_el["acc_norm,none"] // .results.arc_challenge_el["acc_norm,none"]' 100
+print_metric " arc_challenge_es: " "arc_challenge_es" '.results.arc_challenge_es.acc_norm // .results.arc_challenge_mt_es["acc_norm,none"] // .results.arc_challenge_es["acc_norm,none"]' 100
+print_metric " arc_challenge_fr: " "arc_challenge_fr" '.results.arc_challenge_fr.acc_norm // .results.arc_challenge_mt_fr["acc_norm,none"] // .results.arc_challenge_fr["acc_norm,none"]' 100
+print_metric " arc_challenge_hu: " "arc_challenge_hu" '.results.arc_challenge_hu.acc_norm // .results.arc_challenge_mt_hu["acc_norm,none"] // .results.arc_challenge_hu["acc_norm,none"]' 100
+print_metric " arc_challenge_it: " "arc_challenge_it" '.results.arc_challenge_it.acc_norm // .results.arc_challenge_mt_it["acc_norm,none"] // .results.arc_challenge_it["acc_norm,none"]' 100
+print_metric " arc_challenge_nl: " "arc_challenge_nl" '.results.arc_challenge_nl.acc_norm // .results.arc_challenge_mt_nl["acc_norm,none"] // .results.arc_challenge_nl["acc_norm,none"]' 100
+print_metric " arc_challenge_pl: " "arc_challenge_pl" '.results.arc_challenge_pl.acc_norm // .results.arc_challenge_mt_pl["acc_norm,none"] // .results.arc_challenge_pl["acc_norm,none"]' 100
+print_metric " arc_challenge_pt: " "arc_challenge_pt" '.results.arc_challenge_pt.acc_norm // .results.arc_challenge_mt_pt["acc_norm,none"] // .results.arc_challenge_pt["acc_norm,none"]' 100
+
+echo
+print_metric " arc_challenge_bg: " "arc_challenge_bg" '.results.arc_challenge_bg.acc_norm // .results.arc_challenge_mt_bg["acc_norm,none"] // .results.arc_challenge_bg["acc_norm,none"]' 100
+print_metric " arc_challenge_cs: " "arc_challenge_cs" '.results.arc_challenge_cs.acc_norm // .results.arc_challenge_mt_cs["acc_norm,none"] // .results.arc_challenge_cs["acc_norm,none"]' 100
+print_metric " arc_challenge_et: " "arc_challenge_et" '.results.arc_challenge_et.acc_norm // .results.arc_challenge_mt_et["acc_norm,none"] // .results.arc_challenge_et["acc_norm,none"]' 100
+print_metric " arc_challenge_lt: " "arc_challenge_lt" '.results.arc_challenge_lt.acc_norm // .results.arc_challenge_mt_lt["acc_norm,none"] // .results.arc_challenge_lt["acc_norm,none"]' 100
+print_metric " arc_challenge_lv: " "arc_challenge_lv" '.results.arc_challenge_lv.acc_norm // .results.arc_challenge_mt_lv["acc_norm,none"] // .results.arc_challenge_lv["acc_norm,none"]' 100
+print_metric " arc_challenge_ro: " "arc_challenge_ro" '.results.arc_challenge_ro.acc_norm // .results.arc_challenge_mt_ro["acc_norm,none"] // .results.arc_challenge_ro["acc_norm,none"]' 100
+print_metric " arc_challenge_sk: " "arc_challenge_sk" '.results.arc_challenge_sk.acc_norm // .results.arc_challenge_mt_sk["acc_norm,none"] // .results.arc_challenge_sk["acc_norm,none"]' 100
+print_metric " arc_challenge_sl: " "arc_challenge_sl" '.results.arc_challenge_sl.acc_norm // .results.arc_challenge_mt_sl["acc_norm,none"] // .results.arc_challenge_sl["acc_norm,none"]' 100
+
+echo
+# --- code tasks ---
+print_metric " humaneval-unstripped_pass@1: " "humaneval-unstripped_pass@1" '."humaneval-unstripped"."pass@1"' 100
+print_metric "humaneval-unstripped_pass@10: " "humaneval-unstripped_pass@10" '."humaneval-unstripped"."pass@10"' 100
+print_metric " humaneval_pass@1: " "humaneval_pass@1" '.humaneval."pass@1"' 100
+print_metric "humaneval_pass@10: " "humaneval_pass@10" '.humaneval."pass@10"' 100
+print_metric "      mbpp_pass@1: " "mbpp_pass@1" '.mbpp."pass@1"' 100
+print_metric "     mbpp_pass@10: " "mbpp_pass@10" '.mbpp."pass@10"' 100
 
 echo
 
-echo -n "   arc_challenge_da: "
-if [ -f $DIR/arc_challenge_da.json ] ; then 
-    cat $DIR/arc_challenge_da.json | jq '.results.arc_challenge_da.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_da.json ] ; then 
-    cat $DIR/arc_challenge_mt_da.json | jq '.results.arc_challenge_mt_da["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    hellaswag_mt_da: "
-if [ -f $DIR/hellaswag_mt_da.json ] ; then
-    cat $DIR/hellaswag_mt_da.json | jq '.results.ogx_hellaswagx_da."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "         mmlu_mt_da: "
-if [ -f $DIR/mmlu_mt_da.json ] ; then
-    cat $DIR/mmlu_mt_da.json | jq '.groups.ogx_mmlux_DA."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "truthfulqa_mc_mt_da: "
-if [ -f $DIR/truthfulqa_mc_mt_da.json ] ; then
-    cat $DIR/truthfulqa_mc_mt_da.json | jq '.results.ogx_truthfulqax_mc2_da."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "        gsm8k_mt_da: "
-if [ -f $DIR/gsm8k_mt_da.json ] ; then
-    cat $DIR/gsm8k_mt_da.json | jq '.results.ogx_gsm8kx_da."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    flores200_en_da: "
-if [ -f $DIR/flores200_trans_en_da.json ] ; then
-    cat $DIR/flores200_trans_en_da.json | jq '.results."ogx_flores200-trans-eng_Latn-dan_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo -n "    flores200_da_en: "
-if [ -f $DIR/flores200_trans_da_en.json ] ; then
-    cat $DIR/flores200_trans_da_en.json | jq '.results."ogx_flores200-trans-dan_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
+# --- misc QA / reasoning ---
+print_metric "         arc_easy: " "arc_easy" '.results.arc_easy.acc // .results.arc_easy["acc,none"]' 100
+print_metric "            boolq: " "boolq" '.results.boolq.acc // .results.boolq["acc,none"]' 100
+print_metric "          nq_open: " "nq_open" '.results.nq_open.em // .results.nq_open["exact_match,remove_whitespace"]' 100
+print_metric " openbookqa (acc): " "openbookqa" '.results.openbookqa.acc // .results.openbookqa["acc,none"]' 100
+print_metric "       piqa (acc): " "piqa" '.results.piqa.acc // .results.piqa["acc,none"]' 100
+print_metric "      squad2 (f1): " "squad2" '.results.squad2.f1 // .results.squadv2["f1,none"]' 1
+print_metric "         triviaqa: " "triviaqa" '.results.triviaqa.em // .results.triviaqa["exact_match,remove_whitespace"]' 100
 
 echo
 
-echo -n " arc_challenge_is: "
-if [ -f $DIR/arc_challenge_is.json ] ; then 
-    cat $DIR/arc_challenge_is.json | jq '.results.arc_challenge_is.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_is.json ] ; then 
-    cat $DIR/arc_challenge_mt_is.json | jq '.results.arc_challenge_mt_is["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
+# --- safety / other ---
+print_metric "    toxigen (acc): " "toxigen" '.results.toxigen.acc // .results.toxigen["acc,none"]' 100
 
-echo -n "    flores200_en_is: "
-if [ -f $DIR/flores200_trans_en_is.json ] ; then
-    cat $DIR/flores200_trans_en_is.json | jq '.results."ogx_flores200-trans-eng_Latn-isl_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo -n "    flores200_is_en: "
-if [ -f $DIR/flores200_trans_is_en.json ] ; then
-    cat $DIR/flores200_trans_is_en.json | jq '.results."ogx_flores200-trans-isl_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo
-
-
-echo -n " arc_challenge_nb: "
-if [ -f $DIR/arc_challenge_nb.json ] ; then 
-    cat $DIR/arc_challenge_nb.json | jq '.results.arc_challenge_nb.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_nb.json ] ; then 
-    cat $DIR/arc_challenge_mt_nb.json | jq '.results.arc_challenge_mt_nb["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    flores200_en_nb: "
-if [ -f $DIR/flores200_trans_en_nb.json ] ; then
-    cat $DIR/flores200_trans_en_nb.json | jq '.results."ogx_flores200-trans-eng_Latn-nob_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo -n "    flores200_nb_en: "
-if [ -f $DIR/flores200_trans_nb_en.json ] ; then
-    cat $DIR/flores200_trans_nb_en.json | jq '.results."ogx_flores200-trans-nob_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo 
-
-echo -n "   arc_challenge_sv: "
-if [ -f $DIR/arc_challenge_sv.json ] ; then 
-    cat $DIR/arc_challenge_sv.json | jq '.results.arc_challenge_sv.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_sv.json ] ; then 
-    cat $DIR/arc_challenge_mt_sv.json | jq '.results.arc_challenge_mt_sv["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    hellaswag_mt_sv: "
-if [ -f $DIR/hellaswag_mt_sv.json ] ; then
-    cat $DIR/hellaswag_mt_sv.json | jq '.results.ogx_hellaswagx_sv."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "         mmlu_mt_sv: "
-if [ -f $DIR/mmlu_mt_sv.json ] ; then
-    cat $DIR/mmlu_mt_sv.json | jq '.groups.ogx_mmlux_SV."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "truthfulqa_mc_mt_sv: "
-if [ -f $DIR/truthfulqa_mc_mt_sv.json ] ; then
-    cat $DIR/truthfulqa_mc_mt_sv.json | jq '.results.ogx_truthfulqax_mc2_sv."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "        gsm8k_mt_sv: "
-if [ -f $DIR/gsm8k_mt_sv.json ] ; then
-    cat $DIR/gsm8k_mt_sv.json | jq '.results.ogx_gsm8kx_sv."acc,none"' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "    flores200_en_sv: "
-if [ -f $DIR/flores200_trans_en_sv.json ] ; then
-    cat $DIR/flores200_trans_en_sv.json | jq '.results."ogx_flores200-trans-eng_Latn-swe_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo -n "    flores200_sv_en: "
-if [ -f $DIR/flores200_trans_sv_en.json ] ; then
-    cat $DIR/flores200_trans_sv_en.json | jq '.results."ogx_flores200-trans-swe_Latn-eng_Latn"."bleu_flores200,none"' | awk '{print $1 * 1.0}'
-else
-    echo na
-fi
-
-echo
-
-echo -n " arc_challenge_de: "
-if [ -f $DIR/arc_challenge_de.json ] ; then
-    cat $DIR/arc_challenge_de.json | jq '.results.arc_challenge_de.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_de.json ] ; then 
-    cat $DIR/arc_challenge_mt_de.json | jq '.results.arc_challenge_mt_de["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_el: "
-if [ -f $DIR/arc_challenge_el.json ] ; then
-    cat $DIR/arc_challenge_el.json | jq '.results.arc_challenge_el.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_el.json ] ; then 
-    cat $DIR/arc_challenge_mt_el.json | jq '.results.arc_challenge_mt_el["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_es: "
-if [ -f $DIR/arc_challenge_es.json ] ; then
-    cat $DIR/arc_challenge_es.json | jq '.results.arc_challenge_es.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_es.json ] ; then 
-    cat $DIR/arc_challenge_mt_es.json | jq '.results.arc_challenge_mt_es["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_fr: "
-if [ -f $DIR/arc_challenge_fr.json ] ; then
-    cat $DIR/arc_challenge_fr.json | jq '.results.arc_challenge_fr.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_fr.json ] ; then 
-    cat $DIR/arc_challenge_mt_fr.json | jq '.results.arc_challenge_mt_fr["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_hu: "
-if [ -f $DIR/arc_challenge_hu.json ] ; then
-    cat $DIR/arc_challenge_hu.json | jq '.results.arc_challenge_hu.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_hu.json ] ; then 
-    cat $DIR/arc_challenge_mt_hu.json | jq '.results.arc_challenge_mt_hu["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_it: "
-if [ -f $DIR/arc_challenge_it.json ] ; then
-    cat $DIR/arc_challenge_it.json | jq '.results.arc_challenge_it.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_it.json ] ; then 
-    cat $DIR/arc_challenge_mt_it.json | jq '.results.arc_challenge_mt_it["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_nl: "
-if [ -f $DIR/arc_challenge_nl.json ] ; then
-    cat $DIR/arc_challenge_nl.json | jq '.results.arc_challenge_nl.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_nl.json ] ; then 
-    cat $DIR/arc_challenge_mt_nl.json | jq '.results.arc_challenge_mt_nl["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_pl: "
-if [ -f $DIR/arc_challenge_pl.json ] ; then
-    cat $DIR/arc_challenge_pl.json | jq '.results.arc_challenge_pl.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_pl.json ] ; then 
-    cat $DIR/arc_challenge_mt_pl.json | jq '.results.arc_challenge_mt_pl["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-echo -n " arc_challenge_pt: "
-if [ -f $DIR/arc_challenge_pt.json ] ; then
-    cat $DIR/arc_challenge_pt.json | jq '.results.arc_challenge_pt.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_pt.json ] ; then 
-    cat $DIR/arc_challenge_mt_pt.json | jq '.results.arc_challenge_mt_pt["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo
-
-echo -n " arc_challenge_bg: "
-if [ -f $DIR/arc_challenge_bg.json ] ; then
-    cat $DIR/arc_challenge_bg.json | jq '.results.arc_challenge_bg.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_bg.json ] ; then 
-    cat $DIR/arc_challenge_mt_bg.json | jq '.results.arc_challenge_mt_bg["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_cs: "
-if [ -f $DIR/arc_challenge_cs.json ] ; then
-    cat $DIR/arc_challenge_cs.json | jq '.results.arc_challenge_cs.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_cs.json ] ; then 
-    cat $DIR/arc_challenge_mt_cs.json | jq '.results.arc_challenge_mt_cs["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_et: "
-if [ -f $DIR/arc_challenge_et.json ] ; then
-    cat $DIR/arc_challenge_et.json | jq '.results.arc_challenge_et.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_et.json ] ; then 
-    cat $DIR/arc_challenge_mt_et.json | jq '.results.arc_challenge_mt_et["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_lt: "
-if [ -f $DIR/arc_challenge_lt.json ] ; then
-    cat $DIR/arc_challenge_lt.json | jq '.results.arc_challenge_lt.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_lt.json ] ; then 
-    cat $DIR/arc_challenge_mt_lt.json | jq '.results.arc_challenge_mt_lt["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_lv: "
-if [ -f $DIR/arc_challenge_lv.json ] ; then
-    cat $DIR/arc_challenge_lv.json | jq '.results.arc_challenge_lv.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_lv.json ] ; then 
-    cat $DIR/arc_challenge_mt_lv.json | jq '.results.arc_challenge_mt_lv["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_ro: "
-if [ -f $DIR/arc_challenge_ro.json ] ; then
-    cat $DIR/arc_challenge_ro.json | jq '.results.arc_challenge_ro.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_ro.json ] ; then 
-    cat $DIR/arc_challenge_mt_ro.json | jq '.results.arc_challenge_mt_ro["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_sk: "
-if [ -f $DIR/arc_challenge_sk.json ] ; then
-    cat $DIR/arc_challenge_sk.json | jq '.results.arc_challenge_sk.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_sk.json ] ; then 
-    cat $DIR/arc_challenge_mt_sk.json | jq '.results.arc_challenge_mt_sk["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " arc_challenge_sl: "
-if [ -f $DIR/arc_challenge_sl.json ] ; then
-    cat $DIR/arc_challenge_sl.json | jq '.results.arc_challenge_sl.acc_norm' | awk '{print $1 * 100}'
-elif [ -f $DIR/arc_challenge_mt_sl.json ] ; then 
-    cat $DIR/arc_challenge_mt_sl.json | jq '.results.arc_challenge_mt_sl["acc_norm,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo
-
-echo -n " humaneval-unstripped_pass@1: "
-if [ -f $DIR/humaneval-unstripped_pass@1.json ] ; then
-    cat $DIR/humaneval-unstripped_pass@1.json | jq '."humaneval-unstripped"."pass@1"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-
-echo -n "humaneval-unstripped_pass@10: "
-if [ -f $DIR/humaneval-unstripped_pass@10.json ] ; then
-    cat $DIR/humaneval-unstripped_pass@10.json | jq '."humaneval-unstripped"."pass@10"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-echo -n " humaneval_pass@1: "
-if [ -f $DIR/humaneval_pass@1.json ] ; then
-    cat $DIR/humaneval_pass@1.json | jq '.humaneval."pass@1"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-
-echo -n "humaneval_pass@10: "
-if [ -f $DIR/humaneval_pass@10.json ] ; then
-    cat $DIR/humaneval_pass@10.json | jq '.humaneval."pass@10"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-echo -n "      mbpp_pass@1: "
-if [ -f $DIR/mbpp_pass@1.json ] ; then
-    cat $DIR/mbpp_pass@1.json | jq '.mbpp."pass@1"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-
-echo -n "     mbpp_pass@10: "
-if [ -f $DIR/mbpp_pass@10.json ] ; then
-    cat $DIR/mbpp_pass@10.json | jq '.mbpp."pass@10"' | awk '{print $1 * 100 }'
-else
-    echo na
-fi
-
-echo
-
-#   cat $DIR/winogrande2.json | jq '.results.winogrande.acc // .results.winogrande["acc,none"]' | awk '{print $1 * 100}'
-
-echo -n "         arc_easy: "
-if [ -f $DIR/arc_easy.json ] ; then
-    cat $DIR/arc_easy.json | jq '.results.arc_easy.acc // .results.arc_easy["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "            boolq: "
-if [ -f $DIR/boolq.json ] ; then
-    cat $DIR/boolq.json | jq '.results.boolq.acc // .results.boolq["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "          nq_open: "
-if [ -f $DIR/nq_open.json ] ; then
-    cat $DIR/nq_open.json | jq '.results.nq_open.em // .results.nq_open["exact_match,remove_whitespace"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n " openbookqa (acc): "
-if [ -f $DIR/openbookqa.json ] ; then
-    cat $DIR/openbookqa.json | jq '.results.openbookqa.acc // .results.openbookqa["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "       piqa (acc): "
-if [ -f $DIR/piqa.json ] ; then
-    cat $DIR/piqa.json | jq '.results.piqa.acc // .results.piqa["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo -n "      squad2 (f1): "
-if [ -f $DIR/squad2.json ] ; then
-    cat $DIR/squad2.json | jq '.results.squad2.f1 // .results.squadv2["f1,none"]'
-else
-    echo na
-fi
-
-echo -n "         triviaqa: "
-if [ -f $DIR/triviaqa.json ] ; then
-    cat $DIR/triviaqa.json | jq '.results.triviaqa.em // .results.triviaqa["exact_match,remove_whitespace"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-echo
-
-echo -n "    toxigen (acc): "
-if [ -f $DIR/toxigen.json ] ; then
-    cat $DIR/toxigen.json | jq '.results.toxigen.acc // .results.toxigen["acc,none"]' | awk '{print $1 * 100}'
-else
-    echo na
-fi
-
-if [ -f $DIR/belebele_fin.json ] ; then
+# Optional extras (print only if present; also support vllm/timestamped)
+bele_file="$(pick_file "belebele_fin")"
+if [ -n "$bele_file" ]; then
     echo
     echo -n "     belebele_fin: "
-    cat $DIR/belebele_fin.json | jq '.results.belebele_fin_Latn["acc,none"]' | awk '{print $1 * 100}'
+    jq -r '.results.belebele_fin_Latn["acc,none"]' "$bele_file" 2>/dev/null | awk '{print $1 * 100}'
 fi
 
-if [ -f $DIR/ifeval.json ] ; then
+ifeval_file="$(pick_file "ifeval")"
+if [ -n "$ifeval_file" ]; then
     echo
     echo -n "     ifeval prompt_loose: "
-    cat $DIR/ifeval.json | jq '.results.ifeval["prompt_level_loose_acc,none"]' | awk '{print $1 * 100}'
+    jq -r '.results.ifeval["prompt_level_loose_acc,none"]' "$ifeval_file" 2>/dev/null | awk '{print $1 * 100}'
 fi
 
-if [ -f $DIR/ifeval_fi.json ] ; then
+ifeval_fi_file="$(pick_file "ifeval_fi")"
+if [ -n "$ifeval_fi_file" ]; then
     echo -n "     ifeval_fi prompt_loose: "
-    cat $DIR/ifeval_fi.json | jq '.results.ifeval_fi["prompt_level_loose_acc,none"]' | awk '{print $1 * 100}'
+    jq -r '.results.ifeval_fi["prompt_level_loose_acc,none"]' "$ifeval_fi_file" 2>/dev/null | awk '{print $1 * 100}'
 fi
 
-if [ -f $DIR/multi_if.json ] ; then
+multi_if_file="$(pick_file "multi_if")"
+if [ -n "$multi_if_file" ]; then
     echo -n "     multi_if english_average: "
-    cat $DIR/multi_if.json | jq '.results.english_average'
+    jq -r '.results.english_average' "$multi_if_file" 2>/dev/null
 fi
 
-if [ -f $DIR/mtbench_judge_en.json ] ; then
+mtbench_en_file="$(pick_file "mtbench_judge_en")"
+if [ -n "$mtbench_en_file" ]; then
     echo -n "     mtbench_judge_en first_turn_score: "
-    cat $DIR/mtbench_judge_en.json | jq '.results.first_turn_score'
+    jq -r '.results.first_turn_score' "$mtbench_en_file" 2>/dev/null
 fi
 
-if [ -f $DIR/mtbench_judge_fi.json ] ; then
+mtbench_fi_file="$(pick_file "mtbench_judge_fi")"
+if [ -n "$mtbench_fi_file" ]; then
     echo -n "     mtbench_judge_fi first_turn_score: "
-    cat $DIR/mtbench_judge_fi.json | jq '.results.first_turn_score'
+    jq -r '.results.first_turn_score' "$mtbench_fi_file" 2>/dev/null
 fi
 
-if [ -f $DIR/mtbench_judge_en.json ] ; then
+if [ -n "$mtbench_en_file" ]; then
     echo -n "     mtbench_judge_en average_score: "
-    cat $DIR/mtbench_judge_en.json | jq '.results.average_score'
+    jq -r '.results.average_score' "$mtbench_en_file" 2>/dev/null
 fi
 
-if [ -f $DIR/mtbench_judge_fi.json ] ; then
+if [ -n "$mtbench_fi_file" ]; then
     echo -n "     mtbench_judge_fi average_score: "
-    cat $DIR/mtbench_judge_fi.json | jq '.results.average_score'
+    jq -r '.results.average_score' "$mtbench_fi_file" 2>/dev/null
 fi
 
-if [ -f $DIR/alpaca_eval_en.json ] ; then
+alpaca_en_file="$(pick_file "alpaca_eval_en")"
+if [ -n "$alpaca_en_file" ]; then
     echo -n "     alpaca_eval_en length_controlled_winrate: "
-    cat $DIR/alpaca_eval_en.json | jq '.results.length_controlled_winrate'
+    jq -r '.results.length_controlled_winrate' "$alpaca_en_file" 2>/dev/null
 fi
 
-if [ -f $DIR/alpaca_eval_fi.json ] ; then
+alpaca_fi_file="$(pick_file "alpaca_eval_fi")"
+if [ -n "$alpaca_fi_file" ]; then
     echo -n "     alpaca_eval_fi length_controlled_winrate: "
-    cat $DIR/alpaca_eval_fi.json | jq '.results.length_controlled_winrate'
+    jq -r '.results.length_controlled_winrate' "$alpaca_fi_file" 2>/dev/null
 fi
 
 echo

--- a/templates/lm_eval_harness.sh
+++ b/templates/lm_eval_harness.sh
@@ -12,32 +12,39 @@
 #SBATCH --gres={{ slurm_config.gres }}
 #SBATCH --time={{ slurm_config.time }}
 
-# link latest log files
 ln -sf {{ slurm_config.log_dir }}/$SLURM_JOB_ID.out {{ slurm_config.log_dir }}/latest.out
 ln -sf {{ slurm_config.log_dir }}/$SLURM_JOB_ID.err {{ slurm_config.log_dir }}/latest.err
 
 set -euo pipefail
 
-export IMG="/scratch/{{ slurm_config.account }}/containers/vllm_v10.1.1.sif"
-export PRJ="/scratch/{{ slurm_config.account }}"   # will be /project in container
-export SCR="$(pwd -P)"                     # SCR = scratch directory, will be /workspace in container (resolve symlinks)
+echo "Starting lm_eval job..."
+echo "Host: $(hostname)"
+echo "Job ID: $SLURM_JOB_ID"
+
+# LUMI AI Factory container (Ubuntu 24.04, ROCm 6.4, vLLM 0.12)
+export IMG="/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20251209_134408/lumi-multitorch-full-u24r64f21m43t29-20251209_134408.sif"
+# Storage project (use job's account project for storage)
+export STORAGE_PRJ="/scratch/{{ slurm_config.account }}"
+export SCR="$(pwd -P)"
 export ACC="{{ slurm_config.account }}"
 
-# Parse gres for GPU count (e.g., "gpu:mi250:4" -> 4)
+# Parse gres for GPU count
 GRES="{{ slurm_config.gres }}"
 if [[ "$GRES" =~ gpu:[^:]*:([0-9]+) ]]; then
     GPUS="${BASH_REMATCH[1]}"
 elif [[ "$GRES" =~ gpu:([0-9]+) ]]; then
     GPUS="${BASH_REMATCH[1]}"
 else
-    echo "Warning: Could not parse GPU count from GRES '$GRES', defaulting to 4"
-    GPUS=4
+    GPUS=1
 fi
 
-# topology & model knobs
-export N_NODES=1
+export MODEL="{{ env_vars.MODEL }}"
 export TP="$GPUS"
-export MODEL_ID="{{ env_vars.MODEL }}"
+
+echo "Container: $IMG"
+echo "Model: $MODEL"
+echo "GPUs: $GPUS"
+echo "Storage: $STORAGE_PRJ"
 
 {% if env_vars.LM_EVAL_PATH %}
 # Bind mount local lm-eval path into container
@@ -46,164 +53,102 @@ BIND_LM_EVAL="--bind {{ env_vars.LM_EVAL_PATH }}:/workspace/lm-eval-host"
 BIND_LM_EVAL=""
 {% endif %}
 
-srun -A "$ACC" -p "{{ slurm_config.partition }}" -N "$N_NODES" -n1 -t "{{ slurm_config.time }}" --gpus-per-task="$GPUS" \
+# Use srun to properly allocate GPUs to the container
+srun -A "$ACC" -p "{{ slurm_config.partition }}" -N1 -n1 -t "{{ slurm_config.time }}" --gpus-per-task="$GPUS" \
   singularity exec --rocm --cleanenv \
     --bind "$SCR":/workspace \
-    --bind "$PRJ":/project \
+    --bind "$STORAGE_PRJ":/project \
+    --bind /pfs,/scratch,/projappl,/flash,/appl \
+    --bind /var/spool/slurmd \
+    --bind /opt/cray/ \
+    --bind /usr/lib64/libcxi.so.1 \
     --bind /usr/share/libdrm:/usr/share/libdrm \
     $BIND_LM_EVAL \
-    --env SLURM_JOB_ID="$SLURM_JOB_ID" \
-    --env MODEL_ID="$MODEL_ID" \
+    --env MODEL="$MODEL" \
     --env TP="$TP" \
     --env SCR="$SCR" \
     --env USER="$USER" \
+    --env SLURM_JOB_ID="$SLURM_JOB_ID" \
     --env HF_HOME=/project/cache/huggingface \
     --env HUGGINGFACE_HUB_CACHE=/project/cache/huggingface/hub \
-    --env TRANSFORMERS_CACHE=/project/cache/huggingface/models \
-    --env HF_DATASETS_CACHE=/project/cache/huggingface/datasets \
-    --env XDG_CACHE_HOME=/project/cache/huggingface/xdg \
     --env HF_TOKEN="${HF_TOKEN:-}" \
+    --env STORAGE_PRJ="$STORAGE_PRJ" \
     "$IMG" bash -c '
 set -euo pipefail
+echo "Inside container..."
+
+# Group-writable files for shared project cache (locks, downloaded weights)
 umask 002
 
-# Force HOME=/tmp so aiter builds ephemerally and disappears with the job
+# Set HOME to /tmp for ephemeral builds
 export HOME=/tmp
 
-PYTHON_BIN="/opt/miniconda3/envs/pytorch/bin/python"
-export PYTHON_BIN
+source /opt/venv/bin/activate
+PYTHON_BIN="/opt/venv/bin/python"
 
-# ---- env & caches (disable xet + telemetry) ----
+echo "Python: $PYTHON_BIN"
+echo "ROCR_VISIBLE_DEVICES: ${ROCR_VISIBLE_DEVICES:-not set}"
+echo "HIP_VISIBLE_DEVICES: ${HIP_VISIBLE_DEVICES:-not set}"
+$PYTHON_BIN -c "import torch; print(f\"PyTorch: {torch.__version__}, CUDA: {torch.cuda.is_available()}, Devices: {torch.cuda.device_count()}\")"
+$PYTHON_BIN -c "import vllm; print(f\"vLLM: {vllm.__version__}\")"
+
 export HF_HUB_DISABLE_XET=1
-export HF_HUB_ENABLE_HF_TRANSFER=0
-export HF_HUB_DISABLE_TELEMETRY=1
-
-export PATH="/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/miniconda3/envs/pytorch/bin:/usr/local/bin:/usr/bin:/bin"
-export TORCH_EXTENSIONS_DIR=/dev/shm/torch_ext
-export TORCHINDUCTOR_CACHE_DIR=/project/cache/huggingface/torchinductor
-export VLLM_COMPILER_CACHE_DIR=/project/cache/huggingface/vllm-compile
-export TRITON_CACHE_DIR=/project/cache/huggingface/triton
+export MIOPEN_USER_DB_PATH=/tmp/${USER}-miopen-cache
+export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_USER_DB_PATH
+export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
+export NCCL_NET_GDR_LEVEL=3
+export PYTORCH_ROCM_ARCH=gfx90a
 
 export VLLM_USE_V1=1
 export VLLM_TARGET_DEVICE=rocm
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export HIP_ARCHITECTURES=gfx90a
 
-# Avoid the 1-GPU trap - ensure PyTorch uses all allocated GPUs
-unset HIP_VISIBLE_DEVICES
+mkdir -p /project/cache/huggingface/hub "$MIOPEN_USER_DB_PATH"
 
-mkdir -p /project/cache/huggingface/{hub,models,datasets,torchinductor,xdg,vllm-compile,triton} \
-         /dev/shm/torch_ext "$HOME/.aiter/jit/build" "$HOME/.aiter/jit/install" \
-         /tmp/tools
+# Remove stale HF cache lock files that may not be group-writable (multi-user fix)
+find /project/cache/huggingface/hub/.locks -name "*.lock" -delete 2>/dev/null || true
 
-export CC=/opt/rocm/llvm/bin/clang
-export CXX=/opt/rocm/llvm/bin/clang++
+# Clean up any leftover files from previous runs
+rm -rf /tmp/pip-packages /tmp/lm-eval
 
-# Make sure ninja is available
-${PYTHON_BIN} -m pip -q install --user -U ninja || true
+# Install transformers
+PIP_TARGET=/tmp/pip-packages
+mkdir -p "$PIP_TARGET"
+echo "Installing transformers {{ env_vars.TRANSFORMERS_VERSION }}..."
+$PYTHON_BIN -m pip install -q --target="$PIP_TARGET" "numpy<2.3" "transformers=={{ env_vars.TRANSFORMERS_VERSION }}" "hf_transfer"
+export PYTHONPATH="$PIP_TARGET:${PYTHONPATH:-}"
 
-# ------- write helper: stage_aiter.py (NO stdin execution) -------
-cat > /tmp/tools/stage_aiter.py <<PY
-import os, glob, shutil, importlib, pathlib, subprocess, sys
-
-home = os.path.expanduser("~")
-jit_root   = os.path.join(home, ".aiter", "jit")
-build_root = os.path.join(jit_root, "build")
-inst_root  = os.path.join(jit_root, "install")
-pkg_root   = os.path.join(inst_root, "private_aiter")
-pkg_jit    = os.path.join(pkg_root, "jit")
-
-os.makedirs(pkg_jit, exist_ok=True)
-pathlib.Path(os.path.join(pkg_root, "__init__.py")).write_text("")
-pathlib.Path(os.path.join(pkg_jit, "__init__.py")).write_text("")
-
-# trigger a build once (ok if it raises)
-try:
-    import aiter
-    from aiter.ops import enum  # will build module_aiter_enum
-except Exception as e:
-    print("[aiter] prewarm raised:", repr(e))
-
-hits = glob.glob(os.path.join(build_root, "**", "module_aiter_enum*.so"), recursive=True)
-if not hits:
-    raise SystemExit("[stage] no compiled module_aiter_enum*.so found under " + build_root)
-
-so_src = max(hits, key=os.path.getmtime)
-dst = os.path.join(pkg_jit, "module_aiter_enum.so")
-if os.path.islink(dst) or os.path.exists(dst):
-    os.remove(dst)
-try:
-    os.symlink(so_src, dst)
-    print("[stage] symlinked", dst, "->", so_src)
-except OSError:
-    shutil.copy2(so_src, dst)
-    print("[stage] copied", so_src, "->", dst)
-
-print("[ldd]")
-print(subprocess.check_output(["ldd", dst], text=True))
-
-sys.path.insert(0, inst_root)
-m = importlib.import_module("private_aiter.jit.module_aiter_enum")
-print("[stage] import OK:", m.__spec__.origin)
-
-import aiter; from aiter.ops import enum as _e
-print("[stage] aiter import OK")
-PY
-
-# Stage aiter
-${PYTHON_BIN} /tmp/tools/stage_aiter.py
-
-export PYTHONPATH="$HOME/.aiter/jit/install:${PYTHONPATH-}"
-
-# Install specific transformers version
-${PYTHON_BIN} -m pip install --user -q -U transformers=={{ env_vars.TRANSFORMERS_VERSION }}
-
-# ------- get LUMI harness (puts it first on sys.path) -------
 EVAL_HARNESS_DIR="/tmp/lm-eval"
-
-# Function to setup lm-evaluation-harness (no locking needed with job-specific dirs)
-setup_lm_eval() {
-    echo "Setting up lm-evaluation-harness in $EVAL_HARNESS_DIR"
+echo "Setting up lm-evaluation-harness in $EVAL_HARNESS_DIR"
 
 {% if env_vars.LM_EVAL_PATH %}
-    # Use local path - copy from bind-mounted location
-    echo "Using local lm-evaluation-harness from: {{ env_vars.LM_EVAL_PATH }}"
-    cp -r "/workspace/lm-eval-host" "$EVAL_HARNESS_DIR"
+echo "Using local lm-evaluation-harness from: {{ env_vars.LM_EVAL_PATH }}"
+cp -r "/workspace/lm-eval-host" "$EVAL_HARNESS_DIR"
 {% else %}
-    # Use git repository
-    REPO_URL="{{ env_vars.LM_EVAL_REPO }}"
-    REPO_REF="{{ env_vars.LM_EVAL_REF }}"
-
-    echo "Cloning lm-evaluation-harness from $REPO_URL (ref: $REPO_REF)..."
-    git clone --depth 1 -b "$REPO_REF" "$REPO_URL" "$EVAL_HARNESS_DIR"
+REPO_URL="{{ env_vars.LM_EVAL_REPO }}"
+REPO_REF="{{ env_vars.LM_EVAL_REF }}"
+echo "Cloning lm-evaluation-harness from $REPO_URL (ref: $REPO_REF)..."
+git clone --depth 1 -b "$REPO_REF" "$REPO_URL" "$EVAL_HARNESS_DIR"
 {% endif %}
-}
 
-# Setup lm-evaluation-harness
-setup_lm_eval
-export PYTHONPATH="$EVAL_HARNESS_DIR:${PYTHONPATH-}"
+export PYTHONPATH="$EVAL_HARNESS_DIR:${PYTHONPATH:-}"
 
-# Create a temporary directory for lm_eval output
-RANDOM_DIR="/tmp/lm_eval_$(date +%s%N)"
-mkdir -p "$RANDOM_DIR"
-
+# Remap output file path from host to container if needed
 OUTPUT_FILE="{{ env_vars.OUTPUT_FILE }}"
 if [[ "$OUTPUT_FILE" == "$SCR"* ]]; then
-  # map host path under $SCR to the /workspace bind mount
   OUTPUT_FILE="/workspace${OUTPUT_FILE#$SCR}"
 elif [[ "$OUTPUT_FILE" != /* ]]; then
   OUTPUT_FILE="/workspace/$OUTPUT_FILE"
 fi
 mkdir -p "$(dirname "$OUTPUT_FILE")"
 
-# Remap MODEL_ID from host paths to container paths if needed
-if [[ "$MODEL_ID" == /scratch/{{ slurm_config.account }}/* ]]; then
-  MODEL_ID="/project${MODEL_ID#/scratch/{{ slurm_config.account }}}"
-elif [[ "$MODEL_ID" == "$SCR"/* ]]; then
-  MODEL_ID="/workspace${MODEL_ID#$SCR}"
+# Remap MODEL from host paths to container paths if needed
+if [[ "$MODEL" == "$STORAGE_PRJ"/* ]]; then
+  MODEL="/project${MODEL#$STORAGE_PRJ}"
+elif [[ "$MODEL" == "$SCR"/* ]]; then
+  MODEL="/workspace${MODEL#$SCR}"
 fi
 
-# Set up chat template flags
 {% if env_vars.APPLY_CHAT_TEMPLATE %}
 CHAT_TEMPLATE_FLAG="--apply_chat_template"
 {% else %}
@@ -218,31 +163,31 @@ FEWSHOT_AS_MULTITURN_FLAG=""
 
 {% if env_vars.BACKEND == "vllm" %}
 MODEL_BACKEND="vllm"
-MODEL_ARGS="pretrained=${MODEL_ID},dtype=auto,download_dir=/project/cache/huggingface/models,tensor_parallel_size=${TP},max_model_len=4096,gpu_memory_utilization=0.90"
+MODEL_ARGS="pretrained=${MODEL},dtype=auto,tensor_parallel_size=${TP},gpu_memory_utilization=0.90"
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${MODEL_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% endif %}
 {% elif env_vars.BACKEND == "dummy" %}
 MODEL_BACKEND="dummy"
-MODEL_ARGS="pretrained={{ env_vars.MODEL }}"
+MODEL_ARGS="pretrained=${MODEL}"
 {% else %}
 MODEL_BACKEND="hf-auto"
-MODEL_ARGS="pretrained=${MODEL_ID},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
+MODEL_ARGS="pretrained=${MODEL},device_map=auto,dtype=bfloat16,trust_remote_code=True,attn_implementation=sdpa"
 {% if env_vars.MODEL_ARGS %}
 MODEL_ARGS="${MODEL_ARGS},{{ env_vars.MODEL_ARGS }}"
 {% endif %}
 {% endif %}
 
-# Run eval
 BATCH_SIZE="{% if env_vars.BATCH_SIZE %}{{ env_vars.BATCH_SIZE }}{% elif env_vars.BACKEND == "vllm" %}auto{% else %}4{% endif %}"
 
-${PYTHON_BIN} -m lm_eval \
+echo "Running lm_eval with model: $MODEL"
+$PYTHON_BIN -m lm_eval \
   --model "$MODEL_BACKEND" \
   --model_args "$MODEL_ARGS" \
   --tasks "{{ env_vars.TASK_LIST }}" \
   --num_fewshot {{ env_vars.NUM_FEWSHOT }} \
   --batch_size "$BATCH_SIZE" \
-  --output_path "$RANDOM_DIR" \
+  --output_path "$OUTPUT_FILE" \
   $CHAT_TEMPLATE_FLAG \
   $FEWSHOT_AS_MULTITURN_FLAG \
 {% if env_vars.LIMIT %}  --limit {{ env_vars.LIMIT }} \
@@ -250,6 +195,7 @@ ${PYTHON_BIN} -m lm_eval \
 {% if env_vars.LM_EVAL_ARGS %}  {{ env_vars.LM_EVAL_ARGS }}
 {% endif %}
 
-find "$RANDOM_DIR" -name "results_*.json" -exec mv {} "$OUTPUT_FILE" \;
-rm -rf "$RANDOM_DIR"
+echo "lm_eval completed!"
 '
+
+echo "Job finished"


### PR DESCRIPTION
- switch from the old vllm_v10.1.1.sif container to the lumi ai factory container (ubuntu 24.04, rocm 6.4, vllm 0.12)
- rewrite the container setup in the template — remove aiter jit staging (no longe required in 0.12), simplify env vars and bind mounts
- remove hardcoded max_model_len=4096 and download_dir from vllm model args (let vllm auto-detect)
- changed python to python3 in launcher scripts (lumi login nodes don't have python in PATH)
- fix --apply_chat_template and --fewshot_as_multiturn flag passing in cpt-vllm.sh
- rewrite summary.sh to handle timestamped result filenames from newer lm-eval
- default gres from 4 to 8 gpus 
- pin transformers to 4.57.1 (compatible with container's vllm 0.12)

  Test plan

  - ran arc_challenge, truthfulqa_mc, gsm8k, goldenswag with vllm backend — all within stderr of reference values