### PR TITLE
Add TensorWave HELMET + LongPPL eval scripts

### DIFF
--- a/tw/README.md
+++ b/tw/README.md
@@ -1,0 +1,73 @@
+# TensorWave Long-Context Evaluations
+
+HELMET (128K) and LongPPL evaluation scripts for the TensorWave MI325X cluster.
+
+## Setup
+
+Run once from a node with `/shared_silo/scratch` access:
+
+```bash
+ssh tus1-vm-amd-misc-05
+cd /path/to/evals/tw
+bash setup.sh
+```
+
+This clones HELMET and the LumiOpen lm-eval fork, and downloads HELMET data (~34 GB).
+
+By default everything goes under `/shared_silo/scratch/$USER/`. Override with `SCRATCH`:
+
+```bash
+SCRATCH=/shared_silo/scratch/ezosa bash setup.sh
+```
+
+## HELMET
+
+Runs all 7 HELMET categories (recall, rag, longqa, summ, icl, rerank, cite) at 128K context with vLLM on 8 GPUs.
+
+```bash
+# Local model path
+sbatch --export=ALL,MODEL=/shared_silo/scratch/models/Meta-Llama-3.1-8B eval_helmet.sbatch
+
+# HuggingFace model
+sbatch --export=ALL,MODEL=LumiOpen/Llama-Poro-2-Long-Base eval_helmet.sbatch
+
+# Run specific configs only
+sbatch --export=ALL,MODEL=...,CONFIGS='rag.yaml recall.yaml' eval_helmet.sbatch
+```
+
+Base models are auto-detected (no `chat`/`instruct`/`it` suffix) and run without chat templates. Override with `OPTIONS`.
+
+Results go to `$SCRATCH/HELMET/output/<model_name>/`.
+
+## LongPPL
+
+Cross-lingual key-token perplexity (English + Finnish) on 1 GPU.
+
+```bash
+# Standard model
+sbatch --export=ALL,MODEL=/shared_silo/scratch/models/Meta-Llama-3.1-8B eval_longppl.sbatch
+
+# Model needing RoPE scaling (e.g. extending 8K → 32K)
+sbatch --export=ALL,MODEL=LumiOpen/Poro-2-8B-base,ROPE_SCALING=true eval_longppl.sbatch
+```
+
+Results go to `$SCRATCH/eval_results/longppl/`.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MODEL` | (required) | Model path or HF ID |
+| `SCRATCH` | `/shared_silo/scratch/$USER` | Scratch root directory |
+| `IMG` | `rocm_vllm_rocm7.0.0_vllm_0.11.2_20251210.sif` | Container image |
+| `CONFIGS` | all 7 HELMET configs | Space-separated config list (HELMET only) |
+| `TAG` | `v1` | Output tag (HELMET only) |
+| `SEED` | `42` | Random seed (HELMET only) |
+| `ROPE_SCALING` | `false` | Enable RoPE scaling (LongPPL only) |
+| `TASKS` | `crosslingual_longppl_en,crosslingual_longppl_fi` | lm-eval tasks (LongPPL only) |
+
+## Container
+
+Both scripts use the ROCm vLLM container at `/shared_silo/scratch/containers/`. The container needs `ulimit -n 65536` for HELMET's multiprocessing data loader — this is already set in the script.
+
+Dependencies (`pytrec_eval`, `rouge_score`, etc.) are pip-installed into per-job temp dirs at runtime to avoid cross-job interference.

--- a/tw/eval_helmet.sbatch
+++ b/tw/eval_helmet.sbatch
@@ -1,0 +1,107 @@
+#!/bin/bash
+#SBATCH --job-name=helmet
+#SBATCH --partition=amd-tw-verification
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --gpus-per-node=8
+#SBATCH --mem=240G
+#SBATCH --time=24:00:00
+#SBATCH --exclusive
+
+# HELMET 128K long-context evaluation on TensorWave (MI325X).
+# Runs all 7 standard HELMET categories with vLLM (TP=8).
+#
+# Usage:
+#   sbatch --export=ALL,MODEL=/shared_silo/scratch/models/Meta-Llama-3.1-8B eval_helmet.sbatch
+#   sbatch --export=ALL,MODEL=LumiOpen/Llama-Poro-2-Long-Base eval_helmet.sbatch
+#
+# Optional overrides:
+#   SCRATCH   — scratch root (default: /shared_silo/scratch/$USER)
+#   CONFIGS   — space-separated list of HELMET configs (default: all 7)
+#   TAG       — output tag (default: v1)
+#   SEED      — random seed (default: 42)
+#   IMG       — container image path
+
+set -euo pipefail
+
+MODEL="${MODEL:?Set MODEL via --export=ALL,MODEL=...}"
+SCRATCH="${SCRATCH:-/shared_silo/scratch/$USER}"
+HELMET_DIR="${SCRATCH}/HELMET"
+IMG="${IMG:-/shared_silo/scratch/containers/rocm_vllm_rocm7.0.0_vllm_0.11.2_20251210.sif}"
+
+MODEL_SHORT=$(basename "$MODEL")
+TAG="${TAG:-v1}"
+SEED="${SEED:-42}"
+OUTDIR="${HELMET_DIR}/output/${MODEL_SHORT}"
+
+CONFIGS=(${CONFIGS:-recall.yaml rag.yaml longqa.yaml summ.yaml icl.yaml rerank.yaml cite.yaml})
+
+# Detect base vs instruct/chat model
+OPTIONS=""
+shopt -s nocasematch
+if ! [[ $MODEL_SHORT =~ (chat|instruct|it$) ]]; then
+    OPTIONS="--use_chat_template False"
+fi
+shopt -u nocasematch
+
+echo "=== HELMET 128K evaluation ==="
+echo "Job ID:    $SLURM_JOBID"
+echo "Model:     $MODEL"
+echo "Short:     $MODEL_SHORT"
+echo "Options:   $OPTIONS"
+echo "Configs:   ${CONFIGS[*]}"
+echo "Output:    $OUTDIR"
+echo "Start:     $(date)"
+
+mkdir -p "$OUTDIR"
+
+# Log files next to job output
+exec > >(tee -a "${SCRATCH}/eval_results/helmet_${SLURM_JOBID}.out") 2>&1
+
+apptainer exec --rocm \
+    -B /shared_silo/scratch:/shared_silo/scratch:rw \
+    -B /usr/share/libdrm:/usr/share/libdrm:ro \
+    "$IMG" bash -c "
+set -euo pipefail
+ulimit -n 65536
+
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+unset ROCR_VISIBLE_DEVICES
+unset CUDA_VISIBLE_DEVICES
+export HF_HOME=${SCRATCH}/hf_home
+export TOKENIZERS_PARALLELISM=false
+export TRITON_CACHE_DIR=/tmp/triton-\${SLURM_JOB_ID}
+export TORCHINDUCTOR_CACHE_DIR=/tmp/inductor-\${SLURM_JOB_ID}
+export PYTHONUSERBASE=/tmp/pip-helmet-\${SLURM_JOB_ID}
+
+pip install --user pytrec_eval rouge_score sentencepiece absl-py --quiet 2>&1 | tail -3
+
+cd $HELMET_DIR
+
+for CONFIG in ${CONFIGS[*]}; do
+    echo ''
+    echo '======================================='
+    echo \"Running HELMET config: \$CONFIG\"
+    echo '======================================='
+
+    python eval.py \\
+        --config configs/\$CONFIG \\
+        --seed $SEED \\
+        --output_dir output/$MODEL_SHORT \\
+        --tag $TAG \\
+        --model_name_or_path $MODEL \\
+        --use_vllm \\
+        $OPTIONS
+
+    rc=\$?
+    if [ \$rc -eq 0 ]; then
+        echo \"Done: \$CONFIG\"
+    else
+        echo \"FAILED: \$CONFIG (exit \$rc)\"
+    fi
+done
+"
+
+echo "End: $(date)"
+echo "Results in: $OUTDIR"

--- a/tw/eval_longppl.sbatch
+++ b/tw/eval_longppl.sbatch
@@ -1,0 +1,81 @@
+#!/bin/bash
+#SBATCH --job-name=longppl
+#SBATCH --partition=amd-tw-verification
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --gpus-per-node=1
+#SBATCH --mem=128G
+#SBATCH --time=12:00:00
+#SBATCH --exclusive
+
+# LongPPL cross-lingual key-token perplexity evaluation on TensorWave.
+# Uses LumiOpen's lm-eval fork with crosslingual-longppl tasks (en + fi).
+#
+# Usage:
+#   sbatch --export=ALL,MODEL=/shared_silo/scratch/models/Meta-Llama-3.1-8B eval_longppl.sbatch
+#   sbatch --export=ALL,MODEL=LumiOpen/Poro-2-8B-base,ROPE_SCALING=true eval_longppl.sbatch
+#   sbatch --export=ALL,MODEL=LumiOpen/Llama-Poro-2-Long-Base eval_longppl.sbatch
+#
+# Optional overrides:
+#   SCRATCH       — scratch root (default: /shared_silo/scratch/$USER)
+#   ROPE_SCALING  — set to "true" for models needing RoPE extension (default: false)
+#   TASKS         — comma-separated lm-eval tasks (default: en + fi)
+#   IMG           — container image path
+
+set -euo pipefail
+
+MODEL="${MODEL:?Set MODEL via --export=ALL,MODEL=...}"
+SCRATCH="${SCRATCH:-/shared_silo/scratch/$USER}"
+ROPE_SCALING="${ROPE_SCALING:-false}"
+LMEVAL_DIR="${SCRATCH}/lm-eval-longppl"
+IMG="${IMG:-/shared_silo/scratch/containers/rocm_vllm_rocm7.0.0_vllm_0.11.2_20251210.sif}"
+OUTDIR="${SCRATCH}/eval_results/longppl"
+
+MODEL_ARGS="pretrained=${MODEL},dtype=bfloat16,max_length=32768,allow_truncation=true"
+if [ "$ROPE_SCALING" = "true" ]; then
+    MODEL_ARGS="${MODEL_ARGS},auto_rope_scaling=true"
+fi
+
+TASKS="${TASKS:-crosslingual_longppl_en,crosslingual_longppl_fi}"
+
+echo "=== LongPPL evaluation ==="
+echo "Job ID:      $SLURM_JOBID"
+echo "Model:       $MODEL"
+echo "Model args:  $MODEL_ARGS"
+echo "RoPE scale:  $ROPE_SCALING"
+echo "Tasks:       $TASKS"
+echo "Output:      $OUTDIR"
+echo "Start:       $(date)"
+
+mkdir -p "$OUTDIR"
+
+apptainer exec --rocm \
+    -B /shared_silo/scratch:/shared_silo/scratch:rw \
+    -B /usr/share/libdrm:/usr/share/libdrm:ro \
+    "$IMG" bash -c "
+set -euo pipefail
+
+export HIP_VISIBLE_DEVICES=0
+unset CUDA_VISIBLE_DEVICES
+export HF_HOME=${SCRATCH}/hf_home
+export TOKENIZERS_PARALLELISM=false
+export TRITON_CACHE_DIR=/tmp/triton-\${SLURM_JOB_ID}
+export TORCHINDUCTOR_CACHE_DIR=/tmp/inductor-\${SLURM_JOB_ID}
+export PYTHONUSERBASE=/tmp/pip-longppl-\${SLURM_JOB_ID}
+
+pip install --user -e $LMEVAL_DIR --quiet 2>&1 | tail -5
+pip install --user 'transformers>=4.57.1' --quiet 2>&1 | tail -3
+
+echo '--- Running LongPPL ---'
+python -m lm_eval \\
+    --model longppl_hf \\
+    --model_args $MODEL_ARGS \\
+    --tasks $TASKS \\
+    --batch_size 1 \\
+    --output_path $OUTDIR \\
+    --log_samples
+"
+
+echo "End: $(date)"
+echo "Results in: $OUTDIR"

--- a/tw/setup.sh
+++ b/tw/setup.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# One-time setup for HELMET + LongPPL evaluation on TensorWave.
+# Run on a node with access to /shared_silo/scratch:
+#   ssh tus1-vm-amd-misc-05
+#   bash setup.sh
+set -euo pipefail
+
+SCRATCH="${SCRATCH:-/shared_silo/scratch/$USER}"
+
+echo "=== TensorWave eval setup ==="
+echo "Scratch dir: $SCRATCH"
+
+# 1. Clone LumiOpen lm-eval fork (crosslingual-longppl branch)
+LMEVAL_DIR=$SCRATCH/lm-eval-longppl
+if [ -d "$LMEVAL_DIR" ]; then
+    echo "lm-eval-longppl already at $LMEVAL_DIR, pulling latest..."
+    cd "$LMEVAL_DIR" && git pull && cd -
+else
+    echo "Cloning LumiOpen lm-eval-harness (crosslingual-longppl branch)..."
+    git clone -b feature/crosslingual-longppl \
+        https://github.com/LumiOpen/lm-evaluation-harness.git "$LMEVAL_DIR"
+fi
+
+# 2. Clone HELMET
+HELMET_DIR=$SCRATCH/HELMET
+if [ -d "$HELMET_DIR" ]; then
+    echo "HELMET already at $HELMET_DIR, pulling latest..."
+    cd "$HELMET_DIR" && git pull && cd -
+else
+    echo "Cloning HELMET..."
+    git clone https://github.com/princeton-nlp/HELMET.git "$HELMET_DIR"
+fi
+
+# 3. Download HELMET data (~34 GB)
+if [ -d "$HELMET_DIR/data" ] && [ "$(ls -A "$HELMET_DIR/data" 2>/dev/null)" ]; then
+    echo "HELMET data already exists, skipping download."
+else
+    echo "Downloading HELMET data (~34 GB)..."
+    cd "$HELMET_DIR"
+    wget -c https://huggingface.co/datasets/princeton-nlp/HELMET/resolve/main/data.tar.gz
+    echo "Extracting data..."
+    tar -xzf data.tar.gz
+    rm -f data.tar.gz
+    cd -
+fi
+
+# 4. Create output directories
+mkdir -p "$SCRATCH/eval_results/longppl"
+mkdir -p "$SCRATCH/eval_results/helmet"
+mkdir -p "$HELMET_DIR/output"
+
+echo ""
+echo "=== Setup complete ==="
+echo "HELMET repo:    $HELMET_DIR"
+echo "lm-eval fork:   $LMEVAL_DIR"
+echo ""
+echo "Submit evals with:"
+echo "  sbatch --export=ALL,MODEL=<model_path_or_hf_id> eval_helmet.sbatch"
+echo "  sbatch --export=ALL,MODEL=<model_path_or_hf_id> eval_longppl.sbatch"


### PR DESCRIPTION
## Summary

- Adds parameterized sbatch scripts for running **HELMET 128K** and **LongPPL** evaluations on the TensorWave MI325X cluster
- All paths default to `$SCRATCH` (`/shared_silo/scratch/$USER`) — no hardcoded user paths, so anyone can run them directly
- Includes one-time `setup.sh` to clone HELMET + LumiOpen lm-eval fork and download HELMET data (~34 GB)

## Files

| File | Purpose |
|------|---------|
| `tw/setup.sh` | One-time setup: clone repos, download HELMET data |
| `tw/eval_helmet.sbatch` | HELMET 128K eval (8 GPUs, vLLM, all 7 categories) |
| `tw/eval_longppl.sbatch` | LongPPL en+fi eval (1 GPU, lm-eval fork) |
| `tw/README.md` | Usage docs with all env vars documented |

## Quick start

```bash
# Setup (once)
ssh tus1-vm-amd-misc-05
bash setup.sh

# Run HELMET
sbatch --export=ALL,MODEL=LumiOpen/Llama-Poro-2-Long-Base eval_helmet.sbatch

# Run LongPPL
sbatch --export=ALL,MODEL=LumiOpen/Llama-Poro-2-Long-Base eval_longppl.sbatch
```

## Test plan

- [x] Scripts tested on TW cluster with Meta-Llama-3.1-8B and Poro-2-Long-Base
- [x] All 7 HELMET configs complete successfully
- [x] LongPPL en+fi produces valid results
- [ ] Elaine to test with her own checkpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)